### PR TITLE
Add settings popup, Han-character name detection, and English UI/log messages

### DIFF
--- a/src/main/kotlin/DataStorage.kt
+++ b/src/main/kotlin/DataStorage.kt
@@ -51,10 +51,10 @@ class DataStorage {
             nickname.toByteArray(Charsets.UTF_8).size == 2 &&
             nickname.toByteArray(Charsets.UTF_8).size < nicknameStorage[uid]!!.toByteArray(Charsets.UTF_8).size
         ) {
-            logger.debug("닉네임 등록 시도 취소 {} -x> {}",nicknameStorage[uid],nickname)
+            logger.debug("Nickname registration skipped {} -x> {}", nicknameStorage[uid], nickname)
             return
         }
-        logger.debug("닉네임 등록 {} -> {}",nicknameStorage[uid],nickname)
+        logger.debug("Nickname registered {} -> {}", nicknameStorage[uid], nickname)
         nicknameStorage[uid] = nickname
     }
 
@@ -63,7 +63,7 @@ class DataStorage {
         byActorStorage.clear()
         byTargetStorage.clear()
         summonStorage.clear()
-        logger.info("데미지 패킷 초기화됨")
+        logger.info("Damage packets reset")
     }
 
     private fun flushNicknameStorage() {

--- a/src/main/kotlin/DpsCalculator.kt
+++ b/src/main/kotlin/DpsCalculator.kt
@@ -938,18 +938,18 @@ class DpsCalculator(private val dataStorage: DataStorage) {
         for (offset in POSSIBLE_OFFSETS) {
             val possibleOrigin = skillCode - offset
             if (SKILL_CODES.binarySearch(possibleOrigin) >= 0) {
-                logger.debug("추론 성공한 원본 스킬코드 :{}", possibleOrigin)
+                logger.debug("Inferred original skill code: {}", possibleOrigin)
                 return possibleOrigin
             }
         }
-        logger.debug("스킬코드 추론 실패")
+        logger.debug("Failed to infer skill code")
         return null
     }
 
     fun resetDataStorage() {
         dataStorage.flushDamageStorage()
         targetInfoMap.clear()
-        logger.info("대상 데미지 누적 데이터 초기화 완료")
+        logger.info("Target damage accumulation reset")
     }
 
     fun analyzingData(uid: Int) {
@@ -957,21 +957,28 @@ class DpsCalculator(private val dataStorage: DataStorage) {
         dpsData.map.forEach { (_, pData) ->
             logger.debug("-----------------------------------------")
             logger.debug(
-                "닉네임: {} 직업: {} 총 딜량: {} 기여도: {}",
+                "Nickname: {} job: {} total damage: {} contribution: {}",
                 pData.nickname,
                 pData.job,
                 pData.amount,
                 pData.damageContribution
             )
             pData.analyzedData.forEach { (key, data) ->
-                logger.debug("스킬(코드): {} 스킬 총 피해량: {}", SKILL_MAP[key] ?: key, data.damageAmount)
                 logger.debug(
-                    "사용 횟수: {} Critical Hit 횟수: {} Critical Hit 비율:{}",
+                    "Skill (code): {} total damage: {}",
+                    SKILL_MAP[key] ?: key,
+                    data.damageAmount
+                )
+                logger.debug(
+                    "Uses: {} critical hits: {} critical hit rate: {}",
                     data.times,
                     data.critTimes,
                     data.critTimes / data.times * 100
                 )
-                logger.debug("스킬의 딜 지분: {}%", (data.damageAmount / pData.amount * 100).roundToInt())
+                logger.debug(
+                    "Skill damage share: {}%",
+                    (data.damageAmount / pData.amount * 100).roundToInt()
+                )
             }
             logger.debug("-----------------------------------------")
         }

--- a/src/main/kotlin/config/PcapCapturerConfig.kt
+++ b/src/main/kotlin/config/PcapCapturerConfig.kt
@@ -17,7 +17,7 @@ data class PcapCapturerConfig(
             val timeout = PropertyHandler.getProperty("server.timeout")?.toInt() ?: 10
             val snapSize = PropertyHandler.getProperty("server.maxSnapshotSize")?.toInt() ?: 65536
             logger.debug("{},{},{},{}", ip, port, timeout, snapSize)
-            logger.info("프로퍼티스 초기화 완료")
+            logger.info("Properties initialized")
             return PcapCapturerConfig(ip, port, timeout, snapSize)
         }
     }

--- a/src/main/kotlin/packet/CombatPortDetector.kt
+++ b/src/main/kotlin/packet/CombatPortDetector.kt
@@ -15,4 +15,12 @@ object CombatPortDetector {
     }
 
     fun currentPort(): Int? = lockedPort
+
+    @Synchronized
+    fun reset() {
+        if (lockedPort != null) {
+            logger.info("Combat port lock cleared")
+        }
+        lockedPort = null
+    }
 }

--- a/src/main/kotlin/packet/PropertyHandler.kt
+++ b/src/main/kotlin/packet/PropertyHandler.kt
@@ -19,10 +19,10 @@ object PropertyHandler {
                 props.load(fis)
             }
         } catch (e: FileNotFoundException) {
-            logger.info("설정파일이 존재하지 않아 파일을 생성합니다.")
+            logger.info("Settings file not found; creating a new one.")
             FileOutputStream(fname).use {}
         } catch (e: IOException) {
-            logger.error("설정파일 읽기에 실패했습니다.")
+            logger.error("Failed to read settings file.")
         }
     }
 

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ko">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta
@@ -29,6 +29,7 @@
 
           <div class="headerBtns">
             <div class="headerBtn resetBtn"><i data-lucide="rotate-ccw"></i></div>
+            <div class="headerBtn settingsBtn"><i data-lucide="settings"></i></div>
             <div class="headerBtn collapseBtn">
               <i
                 class="collapseIcon"
@@ -41,9 +42,10 @@
           role="dialog"
           aria-modal="true">
           <div class="detailsHeader">
-            <div class="detailsTitle">상세</div>
+            <div class="detailsTitle">Details</div>
             <div class="tooltip">
-              지속 피해의 타격횟수는 총합 치명타, 강타, 완벽, 백어택, 막기 비율에 포함되지 않습니다.
+              Damage over time hits are not included in total crit, double, perfect, back attack, or
+              parry ratios.
             </div>
 
             <div class="closeX detailsClose">×</div>
@@ -54,18 +56,53 @@
 
             <div class="detailsSkills">
               <div class="skillHeader">
-                <div class="cell name center">스킬명</div>
-                <div class="cell center hit">타격횟수</div>
-                <div class="cell center crit">치명타</div>
-                <div class="cell center parry">패리</div>
-                <div class="cell center perfect">완벽</div>
-                <div class="cell center double">강타</div>
-                <div class="cell center back">백어택</div>
-                <div class="cell dmg">누적 피해량</div>
+                <div class="cell name center">Skill</div>
+                <div class="cell center hit">Hits</div>
+                <div class="cell center crit">Crit</div>
+                <div class="cell center parry">Parry</div>
+                <div class="cell center perfect">Perfect</div>
+                <div class="cell center double">Double</div>
+                <div class="cell center back">Back</div>
+                <div class="cell dmg">Total Damage</div>
               </div>
 
               <div class="skills"></div>
             </div>
+          </div>
+        </div>
+        <div
+          class="settingsPanel"
+          role="dialog"
+          aria-modal="true">
+          <div class="settingsHeader">
+            <div class="settingsTitle">Settings</div>
+            <div class="closeX settingsClose">×</div>
+          </div>
+          <div class="settingsBody">
+            <div class="settingsRow">
+              <div class="settingsInfo">
+                <div class="settingsLabel">Locked server</div>
+                <div class="settingsValue">
+                  <span class="lockedIp">-</span>
+                  <span class="lockedPort">-</span>
+                </div>
+              </div>
+              <button class="settingsAction resetDetectBtn">Reset detection</button>
+            </div>
+            <div class="settingsRow settingsRowInput">
+              <label class="settingsLabel" for="characterNameInput">Character name</label>
+              <input
+                id="characterNameInput"
+                class="characterNameInput"
+                placeholder="Enter your character name" />
+            </div>
+            <label class="settingsCheckbox">
+              <input
+                type="checkbox"
+                class="onlyMeCheckbox" />
+              Only show my character
+            </label>
+            <button class="discordButton">Discuss on Discord</button>
           </div>
         </div>
         <div class="list"></div>
@@ -95,12 +132,12 @@
       class="updateModal"
       id="updateModal">
       <div class="updateModalCard">
-        <div class="updateModalTitle">신규 업데이트</div>
+        <div class="updateModalTitle">New update available</div>
         <div
           class="updateModalText"
           id="updateModalText"></div>
         <div class="updateModalActions">
-          <button class="updateModalBtn primary">확인</button>
+          <button class="updateModalBtn primary">OK</button>
         </div>
       </div>
     </div>

--- a/src/main/resources/js/checkRelease.js
+++ b/src/main/resources/js/checkRelease.js
@@ -56,7 +56,7 @@
 
       const latest = (await res.json()).tag_name;
       if (latest && n(latest) > n(current)) {
-        text.textContent = `신규 업데이트가 있습니다!\n\n현재 버전 : v.${current}\n최신 버전 : v.${latest}\n\n 업데이트를 먼저 진행해주세요.`;
+        text.textContent = `A new update is available!\n\nCurrent version: v.${current}\nLatest version: v.${latest}\n\nPlease update before continuing.`;
         modal.classList.add("isOpen");
       }
     }, START_DELAY);

--- a/src/main/resources/js/details.js
+++ b/src/main/resources/js/details.js
@@ -22,16 +22,16 @@ const createDetailsUI = ({
     return Number.isFinite(n) ? `${n.toFixed(1)}%` : "-";
   };
   const STATUS = [
-    { label: "누적 피해량", getValue: (d) => formatNum(d?.totalDmg) },
-    { label: "피해량 기여도", getValue: (d) => pctText(d?.contributionPct) },
+    { label: "Total Damage", getValue: (d) => formatNum(d?.totalDmg) },
+    { label: "Contribution", getValue: (d) => pctText(d?.contributionPct) },
     // { label: "보스 막기비율", getValue: (d) => d?.parry ?? "-" },
     // { label: "보스 회피비율", getValue: (d) => d?.eva ?? "-" },
-    { label: "치명타 비율", getValue: (d) => pctText(d?.totalCritPct) },
-    { label: "완벽 비율", getValue: (d) => pctText(d?.totalPerfectPct) },
-    { label: "강타 비율", getValue: (d) => pctText(d?.totalDoublePct) },
-    { label: "백어택 비율", getValue: (d) => pctText(d?.totalBackPct) },
-    { label: "보스 막기비율", getValue: (d) => pctText(d?.totalParryPct) },
-    { label: "전투시간", getValue: (d) => d?.combatTime ?? "-" },
+    { label: "Crit Rate", getValue: (d) => pctText(d?.totalCritPct) },
+    { label: "Perfect Rate", getValue: (d) => pctText(d?.totalPerfectPct) },
+    { label: "Double Rate", getValue: (d) => pctText(d?.totalDoublePct) },
+    { label: "Back Attack Rate", getValue: (d) => pctText(d?.totalBackPct) },
+    { label: "Parry Rate", getValue: (d) => pctText(d?.totalParryPct) },
+    { label: "Combat Time", getValue: (d) => d?.combatTime ?? "-" },
   ];
 
   const createStatView = (labelText) => {
@@ -176,7 +176,7 @@ const createDetailsUI = ({
       const doubleRate = pct(double, hits);
 
       view.nameEl.textContent = skill.name ?? "";
-      view.hitEl.textContent = `${hits}회`;
+      view.hitEl.textContent = `${hits}`;
       view.critEl.textContent = `${critRate}%`;
 
       view.parryEl.textContent = `${parryRate}%`;
@@ -190,7 +190,7 @@ const createDetailsUI = ({
   };
 
   const render = (details, row) => {
-    detailsTitle.textContent = `${String(row.name)} 상세내역`;
+    detailsTitle.textContent = `${String(row.name)} Details`;
     renderStats(details);
     renderSkills(details);
   };
@@ -217,7 +217,7 @@ const createDetailsUI = ({
 
     openedRowId = rowId;
 
-    detailsTitle.textContent = `${row.name} 상세내역`;
+    detailsTitle.textContent = `${row.name} Details`;
     detailsPanel.classList.add("open");
 
     // 이전 값 비우기

--- a/src/main/resources/js/meter.js
+++ b/src/main/resources/js/meter.js
@@ -170,7 +170,7 @@ const createMeterUI = ({ elList, dpsFormatter, getUserName, onClickUserRow }) =>
         view.prevContribClass = contributionClass;
       }
 
-      view.dpsNumber.textContent = `${dpsFormatter.format(dps)}/초`;
+      view.dpsNumber.textContent = `${dpsFormatter.format(dps)}/s`;
       view.dpsContribution.textContent = `${damageContribution.toFixed(1)}%`;
       const ratio = Math.max(0, Math.min(1, dps / topDps));
       view.fillEl.style.transform = `scaleX(${ratio})`;

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -88,17 +88,56 @@
   }
 }
 .settingsPanel {
-  display: none;
-  flex-direction: column;
-  gap: 12px;
-  padding: 12px;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(8, 16, 32, 0.6);
+  position: absolute;
   color: var(--text-color);
+  display: none;
+  left: 358px;
+  top: 0;
+  width: 420px;
+  border: 1px solid var(--panel-border);
+  background: rgb(12, 22, 40);
+  padding: 12px 8px;
+  border-radius: var(--rounded-lg);
   text-shadow: var(--text-shadow);
+  z-index: 2;
 
   &.isOpen {
     display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .settingsHeader {
+    display: flex;
+    align-items: center;
+    color: var(--title);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 0 16px 10px;
+
+    .settingsTitle {
+      font-weight: 700;
+    }
+
+    .closeX {
+      cursor: pointer;
+      margin-left: auto;
+      user-select: none;
+      font-size: 22px;
+      padding: 2px 8px;
+      border-radius: 4px;
+      transition: 0.2s;
+    }
+
+    .closeX:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+  }
+
+  .settingsBody {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 0 16px 8px;
   }
 
   .settingsRow {
@@ -106,6 +145,10 @@
     align-items: center;
     justify-content: space-between;
     gap: 12px;
+  }
+
+  .settingsRowInput {
+    align-items: flex-start;
   }
 
   .settingsInfo {
@@ -166,6 +209,8 @@
     cursor: pointer;
     background: linear-gradient(90deg, #5865f2, #4e5bd5);
     text-shadow: var(--text-shadow);
+    width: 100%;
+    text-align: center;
   }
 }
 .list {
@@ -526,12 +571,45 @@
 
 .settingsPanel.isOpen {
   display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.settingsPanel .settingsHeader {
+  display: flex;
+  align-items: center;
+  color: var(--title);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0 16px 10px;
+}
+.settingsPanel .settingsHeader .settingsTitle {
+  font-weight: 700;
+}
+.settingsPanel .settingsHeader .closeX {
+  cursor: pointer;
+  margin-left: auto;
+  user-select: none;
+  font-size: 22px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  transition: 0.2s;
+}
+.settingsPanel .settingsHeader .closeX:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+.settingsPanel .settingsBody {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 0 16px 8px;
 }
 .settingsPanel .settingsRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+}
+.settingsPanel .settingsRowInput {
+  align-items: flex-start;
 }
 .settingsPanel .settingsInfo {
   display: flex;
@@ -584,6 +662,8 @@
   cursor: pointer;
   background: linear-gradient(90deg, #5865f2, #4e5bd5);
   text-shadow: var(--text-shadow);
+  width: 100%;
+  text-align: center;
 }
 
 .list .item {


### PR DESCRIPTION
### Motivation
- Provide a small in-app settings UI to let users view/reset the detected server IP/port, enter their character name, and toggle filtering to only show their character on the meter. 
- Improve nickname auto-detection to accept Chinese/Han characters (both Simplified/Traditional) so non-Korean names are recognized.
- Translate visible UI strings and internal logging from Korean to English for wider accessibility.

### Description
- Add a cogwheel `settings` button and a newly-styled popup panel with: locked server info, a `Reset detection` button, a `Character name` input, an `Only show my character` checkbox, and a `Discuss on Discord` button linking to `https://discord.gg/Aion2Global` (`src/main/resources/index.html`, `styles.css`, `js/core.js`).
- Persist and apply character filtering in the frontend via `localStorage` and provide JS hooks to sync name/filters with the backend (`core.js` changes: `setUserName`, `setOnlyShowUser`, `setupSettingsPanel`, `refreshConnectionInfo`).
- Expose backend bridge methods in `BrowserApp.JSBridge` to return connection info (`getConnectionInfo`), reset auto-detection (`resetAutoDetection`), and set the local character name (`setCharacterName`); add `ConnectionInfo` DTO and hook into `PropertyHandler` and `CombatPortDetector` (`src/main/kotlin/webview/BrowserApp.kt`).
- Extend `CombatPortDetector` with a `reset()` method to clear the locked port so the UI reset button can restart auto-detection (`src/main/kotlin/packet/CombatPortDetector.kt`).
- Broaden nickname detection regex to include Han characters by using `\p{IsHan}` in the validator (`src/main/kotlin/packet/StreamProcessor.kt`).
- Translate many UI strings and logging messages from Korean to English across: `index.html`, `js/details.js`, `js/checkRelease.js`, `js/meter.js`, `js/core.js` and various Kotlin logging calls and messages (`StreamProcessor.kt`, `DpsCalculator.kt`, `DataStorage.kt`, `PcapCapturerConfig.kt`, `PropertyHandler.kt`).
- Small UX: change DPS unit display to `/s` and DOT skill label to `DOT`.

### Testing
- Started a static HTTP server to serve the modified `index.html` for quick UI checks (server started successfully). — success.
- Automated UI capture attempts using Playwright were run to open the page and show the settings panel; the Chromium attempt crashed and the Firefox run timed out, so the screenshot step failed (environment/browser issues, not code). — failed (environment).
- Performed automated code searches (`rg`) and local checks to ensure Korean logging/messages were converted where changed and the Han-character regex was applied; these searches verified the intended changes (search checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb6df22fc832db8630057fef9b906)