### PR TITLE
Log window errors and startup diagnostics to in-app debug console

### DIFF
--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -149,9 +149,5 @@
     <script src="./js/checkRelease.js"></script>
 
     <script src="./js/core.js"></script>
-    <script>
-      lucide.createIcons();
-      dpsApp.start();
-    </script>
   </body>
 </html>

--- a/src/main/resources/js/core.js
+++ b/src/main/resources/js/core.js
@@ -1,6 +1,4 @@
 class DpsApp {
-  static instance;
-
   constructor() {
     if (DpsApp.instance) return DpsApp.instance;
 
@@ -411,7 +409,7 @@ class DpsApp {
       }
 
       iconEl.setAttribute("data-lucide", iconName);
-      lucide.createIcons({ root: this.collapseBtn });
+      window.lucide?.createIcons?.({ root: this.collapseBtn });
     });
     this.resetBtn?.addEventListener("click", () => {
       this.resetAll({ callBackend: true });
@@ -549,6 +547,8 @@ class DpsApp {
   }
 }
 
+DpsApp.instance = null;
+
 // 디버그콘솔
 const setupDebugConsole = () => {
   const g = globalThis;
@@ -592,3 +592,37 @@ const setupDebugConsole = () => {
 
 setupDebugConsole();
 const dpsApp = DpsApp.createInstance();
+const debug = globalThis.uiDebug;
+
+window.addEventListener("error", (event) => {
+  debug?.log?.("window.error", {
+    message: event.message,
+    source: event.filename,
+    line: event.lineno,
+    column: event.colno,
+  });
+});
+
+window.addEventListener("unhandledrejection", (event) => {
+  debug?.log?.("unhandledrejection", event.reason);
+});
+
+const startApp = () => {
+  debug?.log?.("startApp", {
+    readyState: document.readyState,
+    hasDpsData: !!window.dpsData,
+    hasJavaBridge: !!window.javaBridge,
+  });
+  window.lucide?.createIcons?.();
+  try {
+    dpsApp.start();
+  } catch (err) {
+    debug?.log?.("startApp.error", err);
+  }
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", startApp, { once: true });
+} else {
+  startApp();
+}


### PR DESCRIPTION
### Motivation
- Improve visibility into runtime failures by surfacing `window` errors and unhandled promise rejections in the in-app debug console.
- Make startup more diagnosable by recording runtime readiness flags and catching exceptions thrown during app initialization.
- Prevent errors from missing icon library calls by using guarded `lucide` calls.

### Description
- Added a `debug` reference to `globalThis.uiDebug` and listeners for `window.error` and `unhandledrejection` that call `debug.log` to surface errors in the overlay console.
- Introduced `startApp` which logs `document.readyState`, presence of `window.dpsData` and `window.javaBridge`, invokes `window.lucide?.createIcons?.()`, and wraps `dpsApp.start()` in a `try/catch` that logs startup errors using `debug.log`.
- Wired `startApp` to run on `DOMContentLoaded` if the document is still loading or immediately otherwise, and replaced direct `lucide.createIcons` calls with the guarded `window.lucide?.createIcons?.()` form.
- Ensured `DpsApp.instance` is initialized via `DpsApp.instance = null` to avoid modern class-field syntax on older JS engines.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bbb92ec40832dbdd5d6d9d2006ca8)