### PR TITLE
Add details panel opacity setting

### DIFF
--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -52,6 +52,19 @@
           </div>
 
           <div class="detailsBody">
+            <div class="detailsSettings">
+              <div class="detailsSettingsLabel">Panel background</div>
+              <div class="detailsSettingsControl">
+                <input
+                  class="detailsOpacityInput"
+                  type="range"
+                  min="20"
+                  max="100"
+                  step="5"
+                  value="100" />
+                <span class="detailsOpacityValue">100%</span>
+              </div>
+            </div>
             <div class="detailsStats"></div>
 
             <div class="detailsSkills">

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -342,7 +342,7 @@
   font-weight: bold;
   width: 1080px;
   border: 1px solid var(--panel-border);
-  background: rgb(12, 22, 40);
+  background: rgba(12, 22, 40, var(--details-bg-opacity, 1));
   padding: 16px 8px;
   border-radius: var(--rounded-lg);
 
@@ -388,6 +388,39 @@
       display: flex;
       justify-content: space-between;
       gap: 12px;
+    }
+  }
+
+  .detailsSettings {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 0 28px 12px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+
+    .detailsSettingsLabel {
+      font-size: 12px;
+      opacity: 0.7;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .detailsSettingsControl {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .detailsOpacityInput {
+      width: 180px;
+    }
+
+    .detailsOpacityValue {
+      font-size: 12px;
+      opacity: 0.75;
+      min-width: 44px;
+      text-align: right;
     }
   }
 


### PR DESCRIPTION
### Motivation
- Provide a user-facing setting in the damage details panel to control the panel background opacity so users can adjust visibility to their preference.
- Persist the chosen opacity so the setting survives reloads and is applied immediately when changed.

### Description
- Add a new settings row in the details panel markup with a range slider and percentage display (`.detailsSettings`, `.detailsOpacityInput`, `.detailsOpacityValue`) in `src/main/resources/index.html`.
- Use a CSS variable to drive panel opacity (`--details-bg-opacity`) and style the new controls in `src/main/resources/styles.css` while replacing the fixed background with `background: rgba(12, 22, 40, var(--details-bg-opacity, 1))`.
- Implement storage, initialization and UI wiring in `src/main/resources/js/core.js` by adding a `detailsBackgroundOpacity` storage key, `setupDetailsPanelSettings()`, `parseDetailsOpacity()` and `setDetailsBackgroundOpacity()` to apply and persist changes, and initialize the controls during app startup.
- Clamp opacity to the 20%–100% range and sync the slider/value display when changed.

### Testing
- Served the built static files with `python -m http.server 8000` and ran a Playwright script that opened `http://127.0.0.1:8000/index.html`, opened the details panel and captured a screenshot (`artifacts/details-settings.png`), and the run completed successfully.
- No unit tests were added or run beyond the end-to-end browser check above which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c712934d4832d8056f122f2f42d17)