### PR TITLE
Fix details panel opacity defaults and initial state (default 50%)

### DIFF
--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -65,8 +65,8 @@
                         min="20"
                         max="100"
                         step="5"
-                        value="75" />
-                      <span class="detailsOpacityValue">75%</span>
+                        value="50" />
+                      <span class="detailsOpacityValue">50%</span>
                     </div>
                   </div>
                 </div>

--- a/src/main/resources/js/core.js
+++ b/src/main/resources/js/core.js
@@ -533,9 +533,12 @@ class DpsApp {
   }
 
   parseDetailsOpacity(value) {
+    if (value === null || value === undefined || value === "") {
+      return 0.5;
+    }
     const parsed = Number(value);
     if (!Number.isFinite(parsed)) {
-      return 0.75;
+      return 0.5;
     }
     return Math.min(1, Math.max(0.2, parsed));
   }

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -342,7 +342,7 @@
   font-weight: bold;
   width: 1080px;
   border: 1px solid var(--panel-border);
-  background: rgba(12, 22, 40, var(--details-bg-opacity, 0.75));
+  background: rgba(12, 22, 40, var(--details-bg-opacity, 0.5));
   padding: 16px 8px;
   border-radius: var(--rounded-lg);
 


### PR DESCRIPTION
### Motivation

- Fix a bug where the details panel could initialize at 20% opacity when no stored value existed because the parser produced a non-finite value and clamping forced the minimum (0.2). 
- Make the intended default opacity 50% and ensure UI, JS, and CSS agree on that value. 

### Description

- Update `parseDetailsOpacity` in `src/main/resources/js/core.js` to treat `null`, `undefined`, or empty strings as `0.5`, and return `0.5` for non-finite parses so the initial open no longer falls back to `0.2` unexpectedly. 
- Change the HTML slider and label default in `src/main/resources/index.html` so the input `value` and displayed percent are `50`. 
- Update the CSS fallback for `--details-bg-opacity` in `src/main/resources/styles.css` to `0.5` so the panel background matches the JS and slider defaults. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c79fb4914832db06a0cfa134cdb36)