### PR TITLE
Refresh detail translations on language change

### DIFF
--- a/src/main/resources/js/core.js
+++ b/src/main/resources/js/core.js
@@ -116,6 +116,7 @@ class DpsApp {
         this.languageSelect.value = lang;
       }
       this.detailsUI?.updateLabels?.();
+      this.detailsUI?.refresh?.();
       if (this.battleTime?.setAnalysisTextProvider) {
         this.battleTime.setAnalysisTextProvider(() =>
           this.i18n?.t("battleTime.analysing", "Analysing data...")

--- a/src/main/resources/js/details.js
+++ b/src/main/resources/js/details.js
@@ -9,6 +9,8 @@ const createDetailsUI = ({
 }) => {
   let openedRowId = null;
   let openSeq = 0;
+  let lastRow = null;
+  let lastDetails = null;
 
   const clamp01 = (v) => Math.max(0, Math.min(1, v));
 
@@ -213,6 +215,8 @@ const createDetailsUI = ({
     detailsTitle.textContent = formatTitle(currentRowName);
     renderStats(details);
     renderSkills(details);
+    lastRow = row;
+    lastDetails = details;
   };
 
   const isOpen = () => detailsPanel.classList.contains("open");
@@ -236,6 +240,7 @@ const createDetailsUI = ({
     }
 
     openedRowId = rowId;
+    lastRow = row;
 
     currentRowName = String(row.name);
     detailsTitle.textContent = formatTitle(currentRowName);
@@ -265,9 +270,16 @@ const createDetailsUI = ({
     openSeq++;
 
     openedRowId = null;
+    lastRow = null;
+    lastDetails = null;
     detailsPanel.classList.remove("open");
   };
   detailsClose?.addEventListener("click", close);
 
-  return { open, close, isOpen, render, updateLabels };
+  const refresh = () => {
+    if (!detailsPanel.classList.contains("open") || !lastRow) return;
+    open(lastRow, { force: true, restartOnSwitch: false });
+  };
+
+  return { open, close, isOpen, render, updateLabels, refresh };
 };


### PR DESCRIPTION
### Motivation
- Open details did not refresh skill names when the app language changed, so translations remained stale in the details panel.

### Description
- Added `lastRow` and `lastDetails` tracking to the details UI in `src/main/resources/js/details.js` and record the last-opened row in `render`/`open` to enable refresh behavior.
- Added a `refresh` method to the details UI that re-opens the last row via `open(lastRow, { force: true, restartOnSwitch: false })` to reload detail data and translated skill names.
- Clear `lastRow`/`lastDetails` on `close` to avoid stale references in `src/main/resources/js/details.js`.
- Invoke the details refresh on language changes by calling `this.detailsUI?.refresh?.();` inside the `i18n.onChange` handler in `src/main/resources/js/core.js`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca0d879a4832dab69744f93841c26)