### PR TITLE
Fallback to Java bridge for i18n resource loading in WebView

### DIFF
--- a/src/main/kotlin/webview/BrowserApp.kt
+++ b/src/main/kotlin/webview/BrowserApp.kt
@@ -83,6 +83,15 @@ class BrowserApp(private val dpsCalculator: DpsCalculator) : Application() {
                 e.printStackTrace()
             }
         }
+
+        fun readResource(path: String): String? {
+            val normalized = if (path.startsWith("/")) path else "/$path"
+            return try {
+                javaClass.getResourceAsStream(normalized)?.bufferedReader()?.use { it.readText() }
+            } catch (e: Exception) {
+                null
+            }
+        }
         fun exitApp() {
           Platform.exit()     
           exitProcess(0)       


### PR DESCRIPTION
### Motivation

- Packaged WebView instances can fail to `fetch` or XHR bundled JSON files, causing the UI language to remain in English; a robust fallback is needed to load i18n files from the application bundle. 

### Description

- Added `readResource` bridge method in `src/main/kotlin/webview/BrowserApp.kt` to expose bundled resource reading to the WebView (`JSBridge.readResource`).
- Improved `src/main/resources/js/i18n.js` JSON loading by adding `parseJsonText`, `normalizeBridgePath`, and `loadJsonFromBridge` helpers and updating `loadJson` to try `fetch`, then XHR text parsing, and finally the Java bridge fallback. 
- Normalized resource path handling and made JSON parsing resilient to malformed inputs so language sets applied reliably when files are read from different environments.

### Testing

- No automated tests were run for this change. 
- Changes were committed and prepared for review; runtime behavior should be verified in a packaged WebView environment where `fetch`/XHR previously failed to load i18n files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca6fa449c832d9863c770159ac770)