### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.tbread"
-version = "1.0-SNAPSHOT"
+version = "0.1.3"
 
 repositories {
     mavenCentral()
@@ -58,7 +58,7 @@ compose.desktop {
             }
             targetFormats(TargetFormat.Msi)
             packageName = "aion2meter-tw"
-            packageVersion = "0.1.1"
+            packageVersion = "0.1.3"
             copyright = "Copyright 2026 Taengu Licensed under MIT License"
         }
 

--- a/src/main/kotlin/webview/BrowserApp.kt
+++ b/src/main/kotlin/webview/BrowserApp.kt
@@ -103,7 +103,7 @@ class BrowserApp(private val dpsCalculator: DpsCalculator) : Application() {
 
     private val debugMode = false
 
-    private val version = "0.1.1"
+    private val version = "0.1.3"
 
 
     override fun start(stage: Stage) {


### PR DESCRIPTION
### Motivation
- Align build/package metadata and the app-reported version string to the new release `0.1.3`.

### Description
- Update project `version` and native distribution `packageVersion` to `0.1.3` in `build.gradle.kts`.
- Update the application-visible `version` constant to `0.1.3` in `src/main/kotlin/webview/BrowserApp.kt`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cb89f0480832d83df2e95b580c299)