### PR TITLE
Temporarily disable nickname pattern 2 parsing

### DIFF
--- a/src/main/kotlin/packet/StreamProcessor.kt
+++ b/src/main/kotlin/packet/StreamProcessor.kt
@@ -136,22 +136,7 @@ class StreamProcessor(private val dataStorage: DataStorage) {
                     }
                 }
             }
-            if (packet.size > innerOffset + 3 && packet[innerOffset + 1] == 0x00.toByte()) {
-                val possibleNameLength = packet[innerOffset + 2].toInt() and 0xff
-                if (packet.size >= innerOffset + possibleNameLength + 3 && possibleNameLength.toInt() != 0) {
-                    val possibleNameBytes = packet.copyOfRange(innerOffset + 3, innerOffset + possibleNameLength + 3)
-                    val possibleName = String(possibleNameBytes, Charsets.UTF_8)
-                    val sanitizedName = sanitizeNickname(possibleName)
-                    if (sanitizedName != null) {
-                        logger.info(
-                            "Potential nickname found in pattern 2: {} (hex={})",
-                            sanitizedName,
-                            toHex(possibleNameBytes)
-                        )
-                        dataStorage.appendNickname(info.value, sanitizedName)
-                    }
-                }
-            }
+            // Pattern 2 disabled temporarily due to unreliable results.
             if (packet.size > innerOffset + 5) {
                 if (packet[innerOffset + 3] == 0x00.toByte() && packet[innerOffset + 4] == 0x07.toByte()) {
                     val possibleNameLength = packet[innerOffset + 5].toInt() and 0xff


### PR DESCRIPTION
### Motivation
- Pattern 2 nickname extraction produced unreliable matches, so it should be disabled while investigating a better heuristic.

### Description
- Removed the branch that parsed "pattern 2" nicknames from `parseNicknameFromBrokenLengthPacket` and replaced it with a short comment noting it is disabled.

### Testing
- No automated tests were run for this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d28827a40832da62365ef74d41631)