### PR TITLE
Add Windows app.manifest and package resource dir to request UAC elevation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A combat analysis (DPS meter) tool for **AION 2**. Lovingly forked from [Aion2-D
 
 3. If AION 2 is already running, **go to the character selection screen first**.
 
-4. Run `aion2meter-tw.exe` **as Administrator** *(installs to C:\Program Files\aion2meter-tw by default)*
+4. Run `aion2meter-tw.exe` **as Administrator** *(installs to C:\Program Files\aion2meter-tw by default; Windows builds embed a manifest that requests elevation via UAC)*
 
 5. If the UI appears, the application has started successfully.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ compose.desktop {
             windows{
                 includeAllModules = true
             }
+            appResourcesRootDir.set(project.layout.projectDirectory.dir("installer-resources/windows"))
             targetFormats(TargetFormat.Msi)
             packageName = "aion2meter-tw"
             packageVersion = "0.1.4"

--- a/installer-resources/windows/app.manifest
+++ b/installer-resources/windows/app.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>


### PR DESCRIPTION
### Motivation
- Fix the earlier approach of trying to pass `--win-uac-admin` via unsupported DSL properties which caused unresolved reference errors during Gradle script compilation.  
- Ensure the Windows distribution requests elevation (UAC) reliably by embedding a Windows manifest instead of relying on unavailable `jpackage`-specific Gradle properties.  
- Make the repository ship a clear, maintainable packaging resource location for Windows-specific files.  
- Clarify user-facing instructions about Windows elevation in the README.

### Description
- Configure Compose Desktop native distributions to use `appResourcesRootDir` by setting `appResourcesRootDir.set(project.layout.projectDirectory.dir("installer-resources/windows"))` inside the `nativeDistributions` block of `build.gradle.kts` so jpackage resources can be provided.  
- Add `installer-resources/windows/app.manifest` containing a manifest with `<requestedExecutionLevel level="requireAdministrator" uiAccess="false" />` so the produced Windows executable requests administrator privileges via UAC.  
- Remove attempts to use unsupported `jpackageArgs`/`jpackage.installerOptions` and instead provide the manifest via the app resources directory.  
- Update `README.md` to mention that Windows builds embed a manifest which requests elevation via UAC.

### Testing
- No automated tests or CI/Gradle packaging runs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d2b791110832dbcd0fd885fb54cd8)