### PR TITLE
Abbreviate total damage values in DMG mode (k/m/b/t)

### DIFF
--- a/src/main/resources/js/core.js
+++ b/src/main/resources/js/core.js
@@ -811,12 +811,32 @@ class DpsApp {
     this.metricToggleBtn.setAttribute("aria-label", ariaLabel);
   }
 
+  formatAbbreviatedNumber(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return "-";
+    const abs = Math.abs(n);
+    const units = [
+      { value: 1e12, suffix: "t" },
+      { value: 1e9, suffix: "b" },
+      { value: 1e6, suffix: "m" },
+      { value: 1e3, suffix: "k" },
+    ];
+    for (const unit of units) {
+      if (abs >= unit.value) {
+        const scaled = (n / unit.value).toFixed(2);
+        const trimmed = scaled.replace(/\.?0+$/, "");
+        return `${trimmed}${unit.suffix}`;
+      }
+    }
+    return this.dpsFormatter.format(n);
+  }
+
   getMetricForRow(row) {
     if (this.displayMode === "totalDamage") {
       const totalDamage = Number(row?.totalDamage) || 0;
       return {
         value: totalDamage,
-        text: this.dpsFormatter.format(totalDamage),
+        text: this.formatAbbreviatedNumber(totalDamage),
       };
     }
     const dps = Number(row?.dps) || 0;


### PR DESCRIPTION
### Motivation
- Improve readability of large total damage numbers in DMG display by showing abbreviated units (e.g. `1.23k`, `1.23m`).

### Description
- Add `formatAbbreviatedNumber` helper to `src/main/resources/js/core.js` to produce compact suffixes (`k`, `m`, `b`, `t`) and trim trailing zeros. 
- Use `formatAbbreviatedNumber` in `getMetricForRow` for `totalDamage` so DMG mode shows abbreviated text instead of full number formatting.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2fb4fa54832d930a2ae6495cd426)