### PR TITLE
Limit release checks to latest 10 and ignore pre-tagged releases

### DIFF
--- a/src/main/resources/js/checkRelease.js
+++ b/src/main/resources/js/checkRelease.js
@@ -1,5 +1,5 @@
 (() => {
-  const API = "https://api.github.com/repos/taengu/Aion2-Dps-Meter/releases/latest";
+  const API = "https://api.github.com/repos/taengu/Aion2-Dps-Meter/releases?per_page=10";
   const URL = "https://github.com/taengu/Aion2-Dps-Meter/releases";
   const START_DELAY = 800,
     RETRY = 500,
@@ -54,7 +54,14 @@
         return;
       }
 
-      const latest = (await res.json()).tag_name;
+      const releases = await res.json();
+      const latest = releases.find((release) => {
+        const tag = String(release?.tag_name || "").trim().toLowerCase();
+        if (tag.startsWith("pre")) {
+          return false;
+        }
+        return !release?.draft && !release?.prerelease;
+      })?.tag_name;
       if (latest && n(latest) > n(current)) {
         const fallback = `A new update is available!\n\nCurrent version: v.${current}\nLatest version: v.${latest}\n\nPlease update before continuing.`;
         text.textContent =


### PR DESCRIPTION
### Motivation
- Reduce latency and API load by limiting the number of releases fetched for update checks to the most recent entries.
- Avoid treating pre-release/draft releases as the latest stable update by excluding tags that start with "pre" and any draft or prerelease entries.

### Description
- Change the release API endpoint from `.../releases/latest` to `.../releases?per_page=10` to fetch up to 10 recent releases.
- Replace reading `tag_name` from the single `/latest` response with parsing the returned releases array and selecting the first eligible release via `Array.find`.
- Exclude releases whose `tag_name` starts with `pre` and any entries where `draft` or `prerelease` are truthy, then use the selected `tag_name` for version comparison.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e370319d4832dab279e535c9ca5b7)