### PR TITLE
Fix damage packet specials offset and raise suspicious damage threshold

### DIFF
--- a/src/main/kotlin/packet/StreamProcessor.kt
+++ b/src/main/kotlin/packet/StreamProcessor.kt
@@ -11,7 +11,7 @@ class StreamProcessor(private val dataStorage: DataStorage) {
 
     data class VarIntOutput(val value: Int, val length: Int)
 
-    private val suspiciousDamageThreshold = 1_000_000
+    private val suspiciousDamageThreshold = 2_000_000
     private val mask = 0x0f
 
     fun onPacketReceived(packet: ByteArray) {
@@ -500,6 +500,7 @@ class StreamProcessor(private val dataStorage: DataStorage) {
         if (offset >= packet.size) return false
 
         val damageType = packet[offset]
+        offset += 1
 
         val andResult = switchInfo.value and mask
         val start = offset


### PR DESCRIPTION
### Motivation
- Parsing previously misaligned the damage-packet "specials" region by not advancing past the damage-type byte, which could cause varint misreads and spuriously large damage values even when actor/target were valid.
- The project had also reduced noisy "suspicious damage" logging by increasing the detection threshold, so both parsing correctness and logging sensitivity are addressed together.

### Description
- Advance the packet parse offset by one after reading the damage-type byte by updating `offset` in `src/main/kotlin/packet/StreamProcessor.kt` to avoid misaligned varint parsing of specials.
- Continue to compute the specials length from `switchInfo.value and mask` and slice the exact range passed to `parseSpecialDamageFlags` using the corrected `start` offset.
- Increase the `suspiciousDamageThreshold` constant from `1_000_000` to `2_000_000` in `src/main/kotlin/packet/StreamProcessor.kt` to reduce false-positive suspicious-damage logs.

### Testing
- No automated tests were run per project/user instruction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e6bd39ab8832da6290b419b1b0845)