### PR TITLE
Add "Last hit by me" target selection mode

### DIFF
--- a/src/main/kotlin/DataStorage.kt
+++ b/src/main/kotlin/DataStorage.kt
@@ -86,6 +86,10 @@ class DataStorage {
         return byTargetStorage
     }
 
+    fun getActorData(): ConcurrentHashMap<Int, ConcurrentSkipListSet<ParsedDamagePacket>> {
+        return byActorStorage
+    }
+
     fun getNickname(): ConcurrentHashMap<Int, String> {
         return nicknameStorage
     }

--- a/src/main/resources/i18n/ui/en.json
+++ b/src/main/resources/i18n/ui/en.json
@@ -55,6 +55,7 @@
       "options": {
         "mostDamage": "Most damage (current)",
         "mostRecent": "Most recently damaged",
+        "lastHitByMe": "Last hit by me",
         "allTargets": "All targets combined"
       }
     }

--- a/src/main/resources/i18n/ui/ko.json
+++ b/src/main/resources/i18n/ui/ko.json
@@ -55,6 +55,7 @@
       "options": {
         "mostDamage": "가장 큰 피해(현재)",
         "mostRecent": "최근 피해 대상",
+        "lastHitByMe": "내가 최근에 공격한 대상",
         "allTargets": "모든 대상 합산"
       }
     }

--- a/src/main/resources/i18n/ui/zh-Hans.json
+++ b/src/main/resources/i18n/ui/zh-Hans.json
@@ -55,6 +55,7 @@
       "options": {
         "mostDamage": "最高伤害（当前）",
         "mostRecent": "最近受伤目标",
+        "lastHitByMe": "我最近攻击的目标",
         "allTargets": "所有目标合并"
       }
     }

--- a/src/main/resources/i18n/ui/zh-Hant.json
+++ b/src/main/resources/i18n/ui/zh-Hant.json
@@ -55,6 +55,7 @@
       "options": {
         "mostDamage": "最高傷害（目前）",
         "mostRecent": "最近受傷目標",
+        "lastHitByMe": "我最近攻擊的目標",
         "allTargets": "所有目標合計"
       }
     }

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -168,6 +168,9 @@
                 <option value="mostRecent" data-i18n="settings.targetSelection.options.mostRecent">
                   Most recently damaged
                 </option>
+                <option value="lastHitByMe" data-i18n="settings.targetSelection.options.lastHitByMe">
+                  Last hit by me
+                </option>
                 <option value="allTargets" data-i18n="settings.targetSelection.options.allTargets">
                   All targets combined
                 </option>


### PR DESCRIPTION
### Motivation

- Provide a target-selection option that lets the meter track the target the local player (or their summons) hit most recently, and prefer the target they hit most frequently in the last 10 seconds when multiple recent targets exist.

### Description

- Add a new target selection enum `LAST_HIT_BY_ME` and implement selection logic in `DpsCalculator.selectTargetLastHitByMe` which uses `LocalPlayer.characterName`, resolves matching actor IDs (including summons), inspects per-actor damage packets, ignores DoT (`isDoT()`), and uses a 10s cutoff to prefer the most frequently hit target, falling back to the single most recent target otherwise (`src/main/kotlin/DpsCalculator.kt`).
- Expose per-actor packet storage via `DataStorage.getActorData()` to support the new selection mode (`src/main/kotlin/DataStorage.kt`).
- Add the new option to the settings UI and include localized labels in English, Korean, Simplified Chinese and Traditional Chinese (`src/main/resources/index.html`, `src/main/resources/i18n/ui/en.json`, `src/main/resources/i18n/ui/ko.json`, `src/main/resources/i18n/ui/zh-Hans.json`, `src/main/resources/i18n/ui/zh-Hant.json`).

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e78a8829c832d9fac56eb0751d775)