### PR TITLE
Improve loopback port selection for local connections

### DIFF
--- a/src/main/kotlin/packet/CaptureDispatcher.kt
+++ b/src/main/kotlin/packet/CaptureDispatcher.kt
@@ -20,6 +20,8 @@ class CaptureDispatcher(
 
     suspend fun run() {
         for (cap in channel) {
+            CombatPortDetector.observeLocalConnection(cap.srcPort, cap.dstPort, cap.deviceName)
+
             val a = minOf(cap.srcPort, cap.dstPort)
             val b = maxOf(cap.srcPort, cap.dstPort)
             val key = a to b
@@ -28,8 +30,8 @@ class CaptureDispatcher(
 
             // "Lock" is informational for now; don't filter until parsing confirmed stable
             if (CombatPortDetector.currentPort() == null && contains(cap.data, MAGIC)) {
-                // Choose srcPort for now (since magic typically comes from the sender)
-                CombatPortDetector.lock(cap.srcPort, cap.deviceName)
+                val preferredPort = CombatPortDetector.bestLocalPort() ?: cap.srcPort
+                CombatPortDetector.lock(preferredPort, cap.deviceName)
                 logger.info(
                     "Magic seen on flow {}-{} (src={}, dst={}, device={})",
                     a,

--- a/src/main/kotlin/packet/CombatPortDetector.kt
+++ b/src/main/kotlin/packet/CombatPortDetector.kt
@@ -6,6 +6,14 @@ object CombatPortDetector {
     private val logger = LoggerFactory.getLogger(CombatPortDetector::class.java)
     @Volatile private var lockedPort: Int? = null
     @Volatile private var lockedDevice: String? = null
+    private val localConnections = mutableMapOf<Pair<Int, Int>, DirectionState>()
+    private val excludedPorts = mutableSetOf<Int>()
+    private val candidatePorts = mutableSetOf<Int>()
+
+    private data class DirectionState(
+        var aToB: Boolean = false,
+        var bToA: Boolean = false
+    )
 
     @Synchronized
     fun lock(port: Int, deviceName: String?) {
@@ -21,6 +29,38 @@ object CombatPortDetector {
         }
     }
 
+    @Synchronized
+    fun observeLocalConnection(srcPort: Int, dstPort: Int, deviceName: String?) {
+        if (!isLoopbackDevice(deviceName)) return
+
+        val a = minOf(srcPort, dstPort)
+        val b = maxOf(srcPort, dstPort)
+        val state = localConnections.getOrPut(a to b) { DirectionState() }
+
+        if (srcPort == a) {
+            state.aToB = true
+        } else {
+            state.bToA = true
+        }
+
+        if (state.aToB && state.bToA) {
+            excludedPorts.add(a)
+            excludedPorts.add(b)
+            candidatePorts.remove(a)
+            candidatePorts.remove(b)
+        } else {
+            if (!excludedPorts.contains(a)) {
+                candidatePorts.add(a)
+            }
+            if (!excludedPorts.contains(b)) {
+                candidatePorts.add(b)
+            }
+        }
+    }
+
+    @Synchronized
+    fun bestLocalPort(): Int? = candidatePorts.maxOrNull()
+
     fun currentPort(): Int? = lockedPort
     fun currentDevice(): String? = lockedDevice
 
@@ -31,5 +71,11 @@ object CombatPortDetector {
         }
         lockedPort = null
         lockedDevice = null
+        localConnections.clear()
+        excludedPorts.clear()
+        candidatePorts.clear()
     }
+
+    private fun isLoopbackDevice(deviceName: String?): Boolean =
+        deviceName?.contains("loopback", ignoreCase = true) == true
 }


### PR DESCRIPTION
### Motivation
- Loopback captures can include bi-directional local app traffic that falsely appears as candidate combat ports.
- The code should avoid locking onto mutual loopback port pairs that represent local-only communication.
- Prefer a more reliable local port when magic bytes are observed on a loopback flow.

### Description
- Added loopback tracking state: `localConnections`, `excludedPorts`, and `candidatePorts`, plus a `DirectionState` data class in `CombatPortDetector` to record per-pair directions.
- Implemented `observeLocalConnection(srcPort,dstPort,deviceName)` to update candidate/excluded sets for loopback flows and added `bestLocalPort()` to pick a preferred candidate.
- Call `CombatPortDetector.observeLocalConnection(...)` for each captured packet in `CaptureDispatcher.run()` and use `bestLocalPort()` as the preferred port when locking after magic detection instead of always using `srcPort`.
- Clear loopback tracking state in `CombatPortDetector.reset()` and add `isLoopbackDevice()` helper.

### Testing
- No automated tests were run for this change (per repository instructions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f3585fa54832db641ea8a488ec84a)