### PR TITLE
Improve CJK font fallbacks for Windows/macOS users

### DIFF
--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -20,7 +20,23 @@
 }
 
 * {
-  font-family: "Pretendard", "Noto Sans KR", "Noto Sans SC", "Noto Sans TC", sans-serif;
+  font-family:
+    "Pretendard",
+    "Noto Sans KR",
+    "Noto Sans SC",
+    "Noto Sans TC",
+    "Microsoft YaHei UI",
+    "Microsoft YaHei",
+    "Microsoft JhengHei UI",
+    "Microsoft JhengHei",
+    "PingFang SC",
+    "PingFang TC",
+    "Heiti SC",
+    "Heiti TC",
+    "SimHei",
+    "Segoe UI",
+    "Arial Unicode MS",
+    sans-serif;
   margin: 0;
   padding: 0;
   -webkit-user-select: none;


### PR DESCRIPTION
### Motivation
- Some users reported garbled characters after switching to Chinese language options, so the global font stack was expanded to provide broader CJK coverage on Windows and macOS.

### Description
- Updated `src/main/resources/styles.css` to expand the global `font-family` fallback list, preserving `Pretendard`/`Noto` entries and adding common Windows and macOS CJK fonts such as `Microsoft YaHei`, `Microsoft JhengHei`, `PingFang`, `Heiti`, `SimHei`, `Segoe UI`, and `Arial Unicode MS`.

### Testing
- No automated tests were run for this change (per project/user instruction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5b599aac832db212c0dbf7d64fb1)