### PR TITLE
Parse length-prefixed nicknames and integrate into nickname scanning

### DIFF
--- a/src/main/kotlin/packet/StreamProcessor.kt
+++ b/src/main/kotlin/packet/StreamProcessor.kt
@@ -659,6 +659,11 @@ class StreamProcessor(private val dataStorage: DataStorage) {
             val possibleName = String(possibleNameBytes, Charsets.UTF_8)
             val sanitizedName = sanitizeNickname(possibleName)
             if (sanitizedName != null) {
+                val sanitizedBytes = sanitizedName.toByteArray(Charsets.UTF_8)
+                if (sanitizedBytes.size != possibleNameBytes.size) {
+                    offset++
+                    continue
+                }
                 logger.info(
                     "Length nickname mapped: actor={} nickname={}",
                     actorInfo.value,


### PR DESCRIPTION
### Motivation
- Capture actor ID + length-prefixed UTF-8 nickname pairs observed in duel packets (e.g. `0x93 0x31 06 ssshh 0x93 0x54 06 deside`) that previous scanning missed.  
- Reduce false positives by requiring 2-byte varints and reasonable actor ID ranges when mapping names.  
- Integrate the new detection path into existing marker/opcode scanning so short/sliced packet buffers are also scanned correctly.

### Description
- Added `scanLengthPrefixedNicknamesInPacket` to discover patterns of `2-byte actor id` + `1-byte name length` + `UTF-8 name` and to append sanitized names via `dataStorage.appendNickname` when valid.  
- Integrated the new scanner into `scanMarkerNicknames` and the packet-slice loop so the length-prefixed detection runs alongside existing `scanMarkerNicknamesInPacket` and opcode-based scanning.  
- Enforced `actorInfo.length == 2` and `actorInfo.value >= 1000` checks before mapping any length-prefixed or opcode/marker nicknames, and skip empty nickname ranges to avoid spurious matches.  
- Preserved and added diagnostic logging (including `toHex` output) when potential nicknames are detected.  
- Kept existing opcode-based scanning helpers (`scanOpcodeNicknamesInPacket`, `isOpcodeNicknameMarker`, `scanOpcodeNicknameAtOffset`, `findActorIdBeforeOpcode`) and ensured they remain part of the combined scanning flow.

### Testing
- No automated tests were run for this change per repository/test instructions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fb5be8a8c832d92efb054120e7b37)