### PR TITLE
Prefer final damage candidate, evaluate tail candidates, and normalize skill IDs

### DIFF
--- a/src/main/kotlin/packet/StreamProcessor.kt
+++ b/src/main/kotlin/packet/StreamProcessor.kt
@@ -919,7 +919,17 @@ class StreamProcessor(private val dataStorage: DataStorage) {
                     hitDamages.add(hitInfo.value)
                     hitsRead++
                 }
-                resolvedDamage = totalDamage
+                resolvedDamage = if (hitsRead == hitCount) {
+                    totalDamage
+                } else {
+                    logger.debug(
+                        "Hit-count mismatch expected={} read={} using base damage {}",
+                        hitCount,
+                        hitsRead,
+                        damageInfo.value
+                    )
+                    damageInfo.value
+                }
             }
 
             val skillCode = rawSkillCode


### PR DESCRIPTION
### Motivation
- Damage tails can contain multiple varint patterns and the parser must not commit to the first sane varint as final damage. 
- Skill inference must be performed only after damage resolution to avoid offset corruption and false skill normalization. 
- Skill IDs use different encodings (player skills vs short summon/legacy IDs) and must be normalized, not forced into a fallback 300xxxx range.

### Description
- Add candidate evaluation for tail parsing that probes three patterns and chooses priority-wise: hit-count pattern (N hits summed), triple-varint pattern (unknown, damage, loop), then a single-varint fallback. 
- Prefer the resolved final damage (sum of hits for hit-count, or the triple damage) and apply sanity checks (`hitDamageSum >= maxHit` and `hitDamageSum <= numbersSum`, `tripleLoop in 0..32` and `tripleDamage >= max(unknown, loop)`) to accept candidates. 
- Decouple skill-code normalization from damage parsing by resolving damage first and then computing `skillCode`, and treat extended/marker-encoded skills as effect-only (skillCode = 0). 
- Normalize raw skill values by applying `raw >= 10_000_000 ? raw / 100 : raw` so player skills are mapped to the expected code while short summon/legacy IDs are preserved. 

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e3a64df4832dbd51895f4ccb8e48)