### PR TITLE
Fix special byte vararg type and finalize special/heal parsing changes

### DIFF
--- a/src/main/kotlin/entity/AnalyzedSkill.kt
+++ b/src/main/kotlin/entity/AnalyzedSkill.kt
@@ -17,7 +17,8 @@ data class AnalyzedSkill(
     var backTimes: Int = 0,
     var perfectTimes: Int = 0,
     var doubleTimes: Int = 0,
-    var parryTimes: Int = 0
+    var parryTimes: Int = 0,
+    var healAmount: Int = 0
 ) {
-    constructor(pdp:ParsedDamagePacket) : this(pdp.getSkillCode1(),0,0,0,0,0,DpsCalculator.SKILL_MAP[pdp.getSkillCode1()] ?: "",0,0,0)
+    constructor(pdp:ParsedDamagePacket) : this(pdp.getSkillCode1(),0,0,0,0,0,DpsCalculator.SKILL_MAP[pdp.getSkillCode1()] ?: "",0,0,0,0)
 }

--- a/src/main/kotlin/entity/ParsedDamagePacket.kt
+++ b/src/main/kotlin/entity/ParsedDamagePacket.kt
@@ -20,6 +20,7 @@ class ParsedDamagePacket {
         private var dot = false
         private var multiHitCount = 0
         private var multiHitDamage = 0
+        private var healAmount = 0
 
         fun setSpecials(specials: List<SpecialDamage>) {
                 this.specials = specials
@@ -60,6 +61,9 @@ class ParsedDamagePacket {
         fun setMultiHitDamage(damage: Int) {
                 this.multiHitDamage = damage
         }
+        fun setHealAmount(healAmount: Int) {
+                this.healAmount = healAmount
+        }
 
         fun getActorId(): Int {
                 return this.actorId
@@ -99,6 +103,9 @@ class ParsedDamagePacket {
         }
         fun getMultiHitDamage(): Int {
                 return this.multiHitDamage
+        }
+        fun getHealAmount(): Int {
+                return this.healAmount
         }
         fun getTimeStamp(): Long {
                 return this.timestamp

--- a/src/main/kotlin/entity/PersonalData.kt
+++ b/src/main/kotlin/entity/PersonalData.kt
@@ -30,6 +30,9 @@ data class PersonalData(
             analyzedData[pdp.getSkillCode1()] = analyzedSkill
         }
         val analyzedSkill = analyzedData[pdp.getSkillCode1()]!!
+        if (pdp.getHealAmount() > 0) {
+            analyzedSkill.healAmount += pdp.getHealAmount()
+        }
         if (pdp.isDoT()) {
             analyzedSkill.dotTimes ++
             analyzedSkill.dotDamageAmount += pdp.getDamage()

--- a/src/main/kotlin/entity/SpecialDamage.kt
+++ b/src/main/kotlin/entity/SpecialDamage.kt
@@ -1,5 +1,13 @@
 package com.tbread.entity
 
 enum class SpecialDamage {
-    BACK,CRITICAL,PARRY,PERFECT,DOUBLE,ENDURE,UNKNOWN4,POWER_SHARD
+    BACK,
+    CRITICAL,
+    PARRY,
+    PERFECT,
+    DOUBLE,
+    ENDURE,
+    UNKNOWN4,
+    POWER_SHARD,
+    SMITE
 }

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -97,6 +97,7 @@
                 <div class="cell center perfect" data-i18n="details.skills.perfect">Perfect</div>
                 <div class="cell center double" data-i18n="details.skills.double">Double</div>
                 <div class="cell center back" data-i18n="details.skills.back">Back</div>
+                <div class="cell center heal" data-i18n="details.skills.heal">Heal</div>
                 <div class="cell dmg" data-i18n="details.skills.totalDamage">Total Damage</div>
               </div>
 

--- a/src/main/resources/js/core.js
+++ b/src/main/resources/js/core.js
@@ -432,6 +432,7 @@ class DpsApp {
         back = 0,
         perfect = 0,
         double = 0,
+        heal = 0,
         countForTotals = true,
       }) => {
         const dmgInt = Math.trunc(Number(String(dmg ?? "").replace(/,/g, ""))) || 0;
@@ -459,6 +460,7 @@ class DpsApp {
           back: Number(back) || 0,
           perfect: Number(perfect) || 0,
           double: Number(double) || 0,
+          heal: Number(heal) || 0,
           dmg: dmgInt,
         });
       };
@@ -474,6 +476,7 @@ class DpsApp {
         back: value.backTimes,
         perfect: value.perfectTimes,
         double: value.doubleTimes,
+        heal: value.healAmount,
       });
 
       // 도트피해

--- a/src/main/resources/js/details.js
+++ b/src/main/resources/js/details.js
@@ -30,9 +30,9 @@ const createDetailsUI = ({
 
   const STATUS = [
     { key: "details.stats.totalDamage", fallback: "Total Damage", getValue: (d) => formatNum(d?.totalDmg) },
+    { key: "details.stats.contribution", fallback: "Contribution", getValue: (d) => pctText(d?.contributionPct) },
     { key: "details.stats.multiHitDamage", fallback: "Multi-hit Damage", getValue: (d) => formatNum(d?.multiHitDamage) },
     { key: "details.stats.multiHitHits", fallback: "Multi-hit Hits", getValue: (d) => formatNum(d?.multiHitCount) },
-    { key: "details.stats.contribution", fallback: "Contribution", getValue: (d) => pctText(d?.contributionPct) },
     // { label: "보스 막기비율", getValue: (d) => d?.parry ?? "-" },
     // { label: "보스 회피비율", getValue: (d) => d?.eva ?? "-" },
     { key: "details.stats.critRate", fallback: "Crit Rate", getValue: (d) => pctText(d?.totalCritPct) },
@@ -106,6 +106,9 @@ const createDetailsUI = ({
     const doubleEl = document.createElement("div");
     doubleEl.className = "cell center double";
 
+    const healEl = document.createElement("div");
+    healEl.className = "cell center heal";
+
     const dmgEl = document.createElement("div");
     dmgEl.className = "cell dmg right";
 
@@ -125,6 +128,7 @@ const createDetailsUI = ({
     rowEl.appendChild(perfectEl);
     rowEl.appendChild(doubleEl);
     rowEl.appendChild(backEl);
+    rowEl.appendChild(healEl);
 
     rowEl.appendChild(dmgEl);
 
@@ -137,6 +141,7 @@ const createDetailsUI = ({
       backEl,
       perfectEl,
       doubleEl,
+      healEl,
       dmgFillEl,
       dmgTextEl,
     };
@@ -185,6 +190,7 @@ const createDetailsUI = ({
       const perfect = skill.perfect || 0;
       const double = skill.double || 0;
       const back = skill.back || 0;
+      const heal = skill.heal || 0;
 
       const pct = (num, den) => (den > 0 ? Math.round((num / den) * 100) : 0);
 
@@ -204,6 +210,7 @@ const createDetailsUI = ({
       view.backEl.textContent = `${backRate}%`;
       view.perfectEl.textContent = `${perfectRate}%`;
       view.doubleEl.textContent = `${doubleRate}%`;
+      view.healEl.textContent = `${formatNum(heal)}`;
 
       view.dmgTextEl.textContent = `${formatNum(damage)} (${damageRate.toFixed(1)}%)`;
       view.dmgFillEl.style.transform = `scaleX(${barFillRatio})`;

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -997,6 +997,9 @@
   justify-content: center;
   flex: 0 0 56px;
 }
+.detailsPanel .detailsSkills .cell.heal {
+  flex: 0 0 72px;
+}
 .detailsPanel .detailsSkills .cell.dmg {
   flex: 0 0 220px;
   justify-content: center;


### PR DESCRIPTION
### Motivation
- Prevent misinterpretation of bytes as special flags by only consuming a dedicated special-flag byte when an explicit marker is present.  
- Replace unreliable ad-hoc bit parsing by using a trusted bit mask and derive `CRITICAL` from `damageType`.  
- Capture heal values embedded after multi-hit data and propagate them to skill/summary data and the UI.  
- Resolve a Kotlin type mismatch when constructing a `byteArrayOf` from an `Int`-typed special byte to fix compilation.

### Description
- Updated `StreamProcessor` to detect the `[byte][0x00]` marker and only consume the special flag byte when present, adjusting `reader.offset` accordingly.  
- Simplified `parseSpecialDamageFlags` to `private fun parseSpecialDamageFlags(packet: ByteArray): List<SpecialDamage>` and added a trusted `flagMask` to ignore packets without relevant bits, while keeping `CRITICAL` added when `damageType == 3`.  
- Added multi-hit and heal handling in `StreamProcessor`, including detection of the heal marker, reading heal varint, setting `healAmount` on `ParsedDamagePacket`, and adjusting `adjustedDamage` when multi-hit data is present.  
- Propagated heal through data models by adding `healAmount` to `ParsedDamagePacket`, `healAmount` to `AnalyzedSkill`, and accumulating per-skill heals in `PersonalData.processPdp`.  
- Exposed heal totals in the UI by adding a heal column in `index.html`, passing and rendering `heal` in `js/core.js` and `js/details.js`, and adding layout styles in `styles.css`.  
- Added `SMITE` to `SpecialDamage` to reflect the updated trusted-bit mapping.  
- Fixed a Kotlin compile-time type error by casting the extracted special byte to `Byte` in the call `byteArrayOf(specialByte.toByte())`.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69835f695c54832dad242bd3599e71fd)