### PR TITLE
Add actorIdFilter setting and filter parsed damage; update Details settings UI and i18n

### DIFF
--- a/src/main/resources/i18n/ui/en.json
+++ b/src/main/resources/i18n/ui/en.json
@@ -43,6 +43,8 @@
     "resetDetection": "Reset detection",
     "characterName": "Character name",
     "characterNamePlaceholder": "Enter your character name",
+    "actorIdFilter": "Actor ID filter (optional)",
+    "actorIdFilterPlaceholder": "e.g. 12345, 67890",
     "onlyMe": "Only show my character",
     "debugLogging": "Enable debug logging",
     "quit": "Quit",

--- a/src/main/resources/i18n/ui/ko.json
+++ b/src/main/resources/i18n/ui/ko.json
@@ -43,6 +43,8 @@
     "resetDetection": "감지 초기화",
     "characterName": "캐릭터 이름",
     "characterNamePlaceholder": "캐릭터 이름 입력",
+    "actorIdFilter": "액터 ID 필터 (선택)",
+    "actorIdFilterPlaceholder": "예: 12345, 67890",
     "onlyMe": "내 캐릭터만 표시",
     "debugLogging": "디버그 로그 활성화",
     "quit": "종료",

--- a/src/main/resources/i18n/ui/zh-Hans.json
+++ b/src/main/resources/i18n/ui/zh-Hans.json
@@ -43,6 +43,8 @@
     "resetDetection": "重置检测",
     "characterName": "角色名称",
     "characterNamePlaceholder": "输入你的角色名称",
+    "actorIdFilter": "角色 ID 过滤（可选）",
+    "actorIdFilterPlaceholder": "例如：12345, 67890",
     "onlyMe": "仅显示我的角色",
     "debugLogging": "启用调试日志",
     "quit": "退出",

--- a/src/main/resources/i18n/ui/zh-Hant.json
+++ b/src/main/resources/i18n/ui/zh-Hant.json
@@ -43,6 +43,8 @@
     "resetDetection": "重置偵測",
     "characterName": "角色名稱",
     "characterNamePlaceholder": "輸入你的角色名稱",
+    "actorIdFilter": "角色 ID 篩選（選用）",
+    "actorIdFilterPlaceholder": "例如：12345, 67890",
     "onlyMe": "只顯示我的角色",
     "debugLogging": "啟用除錯記錄",
     "quit": "結束",

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -138,6 +138,19 @@
                 placeholder="Enter your character name"
                 data-i18n-placeholder="settings.characterNamePlaceholder" />
             </div>
+            <div class="settingsRow settingsRowInput">
+              <label
+                class="settingsLabel"
+                for="actorIdFilterInput"
+                data-i18n="settings.actorIdFilter">
+                Actor ID filter (optional)
+              </label>
+              <input
+                id="actorIdFilterInput"
+                class="actorIdFilterInput"
+                placeholder="e.g. 12345, 67890"
+                data-i18n-placeholder="settings.actorIdFilterPlaceholder" />
+            </div>
             <label class="settingsCheckbox">
               <input
                 type="checkbox"

--- a/src/main/resources/js/core.js
+++ b/src/main/resources/js/core.js
@@ -15,6 +15,7 @@ class DpsApp {
       displayMode: "dpsMeter.displayMode",
       language: "dpsMeter.language",
       debugLogging: "dpsMeter.debugLoggingEnabled",
+      actorIdFilter: "dpsMeter.actorIdFilter",
     };
 
     this.dpsFormatter = new Intl.NumberFormat("en-US");
@@ -615,12 +616,14 @@ class DpsApp {
     this.quitButton = document.querySelector(".quitButton");
     this.languageSelect = document.querySelector(".languageSelect");
     this.targetSelect = document.querySelector(".targetSelect");
+    this.actorIdFilterInput = document.querySelector(".actorIdFilterInput");
 
     const storedName = this.safeGetStorage(this.storageKeys.userName) || "";
     const storedOnlyShow = this.safeGetStorage(this.storageKeys.onlyShowUser) === "true";
     const storedDebugLogging = this.safeGetSetting(this.storageKeys.debugLogging) === "true";
     const storedTargetSelection = this.safeGetStorage(this.storageKeys.targetSelection);
     const storedLanguage = this.safeGetStorage(this.storageKeys.language);
+    const storedActorFilter = this.safeGetSetting(this.storageKeys.actorIdFilter) || "";
 
     this.setUserName(storedName, { persist: false, syncBackend: true });
     this.setOnlyShowUser(storedOnlyShow, { persist: false });
@@ -630,6 +633,7 @@ class DpsApp {
       syncBackend: true,
       reason: storedTargetSelection ? "restore from storage" : "default selection",
     });
+    this.setActorIdFilter(storedActorFilter, { persist: false, syncBackend: false });
     if (storedLanguage) {
       this.i18n?.setLanguage?.(storedLanguage, { persist: false });
     }
@@ -647,6 +651,14 @@ class DpsApp {
       this.onlyMeCheckbox.addEventListener("change", (event) => {
         const isChecked = !!event.target?.checked;
         this.setOnlyShowUser(isChecked, { persist: true });
+      });
+    }
+
+    if (this.actorIdFilterInput) {
+      this.actorIdFilterInput.value = storedActorFilter;
+      this.actorIdFilterInput.addEventListener("input", (event) => {
+        const value = event.target?.value ?? "";
+        this.setActorIdFilter(value, { persist: true, syncBackend: true });
       });
     }
 
@@ -837,6 +849,20 @@ class DpsApp {
     }
     if (syncBackend) {
       window.javaBridge?.setDebugLoggingEnabled?.(this.debugLoggingEnabled);
+    }
+  }
+
+  setActorIdFilter(value, { persist = false, syncBackend = false } = {}) {
+    const nextValue = String(value ?? "").trim();
+    if (this.actorIdFilterInput && document.activeElement !== this.actorIdFilterInput) {
+      this.actorIdFilterInput.value = nextValue;
+    }
+    if (persist) {
+      if (syncBackend) {
+        this.safeSetSetting(this.storageKeys.actorIdFilter, nextValue);
+      } else {
+        this.safeSetStorage(this.storageKeys.actorIdFilter, nextValue);
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- Introduce an optional actor ID filter to control which incoming damage packets the meter accepts, and expose this option in the UI so users can limit DPS tracking to specific actor IDs (including summon mappings). 
- Surface Details-related settings (panel background / settings flow) and localized strings so the new option is discoverable and translatable. 
- Improve damage parsing acceptance logic to reject self-damage and non-positive damage before appending to storage.

### Description
- Added a new settings input to the Settings panel (`actorIdFilterInput`) and wired it into the frontend storage flow with a new storage key `dpsMeter.actorIdFilter` in `src/main/resources/index.html` and `src/main/resources/js/core.js`. 
- Added localized labels and placeholders for the actor ID filter in `en`, `ko`, `zh-Hans`, and `zh-Hant` i18n files. 
- Implemented filtering logic inside `StreamProcessor` (`src/main/kotlin/packet/StreamProcessor.kt`) including `shouldAcceptDamage`, `isActorIdAllowed`, `getActorIdFilter`, and `parseActorIdFilter`, with caching of the parsed filter string and support for summon ↔ summoner mapping when resolving allowed actor IDs. 
- Replaced the previous naive self-damage check with `shouldAcceptDamage(pdp)` so only allowed, positive, non-self damage is appended to `DataStorage`. 

### Testing
- No automated unit or integration tests were executed as part of this change. 
- A quick UI screenshot attempt via Playwright was attempted but Chromium crashed (SIGSEGV) so no screenshot verification was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698396911670832d946694696c33829f)