### PR TITLE
Restore nickname parsing helpers and payload tracking

### DIFF
--- a/src/main/kotlin/entity/ParsedDamagePacket.kt
+++ b/src/main/kotlin/entity/ParsedDamagePacket.kt
@@ -21,6 +21,7 @@ class ParsedDamagePacket {
         private var multiHitCount = 0
         private var multiHitDamage = 0
         private var healAmount = 0
+        private var hexPayload: String = ""
 
         fun setSpecials(specials: List<SpecialDamage>) {
                 this.specials = specials
@@ -64,6 +65,9 @@ class ParsedDamagePacket {
         fun setHealAmount(healAmount: Int) {
                 this.healAmount = healAmount
         }
+        fun setHexPayload(hexPayload: String) {
+                this.hexPayload = hexPayload
+        }
 
         fun getActorId(): Int {
                 return this.actorId
@@ -106,6 +110,9 @@ class ParsedDamagePacket {
         }
         fun getHealAmount(): Int {
                 return this.healAmount
+        }
+        fun getHexPayload(): String {
+                return this.hexPayload
         }
         fun getTimeStamp(): Long {
                 return this.timestamp


### PR DESCRIPTION
### Motivation
- Restore actor/nickname binding logic that was present in earlier changes to recover nickname prepopulation and binding behavior.
- Fix unresolved reference errors to `getHexPayload` used during skill inference by preserving damage packet hex payloads.
- Ensure damage parsing records the original packet hex so later analysis (skill inference/logging) has access to the raw payload.

### Description
- Added a `hexPayload` field with `setHexPayload`/`getHexPayload` to `ParsedDamagePacket` to expose raw packet hex data.  
- Populate the new payload field in `StreamProcessor` by calling `pdp.setHexPayload(toHex(packet))` in both the main damage parsing and DoT parsing paths.  
- Restored actor/nickname parsing helpers in `StreamProcessor` including `parseActorNameBindingRules`, `parseLootAttributionActorName`, `readAsciiName`, `registerAsciiNickname`, `actorExists`, `actorAppearsInCombat`, `canReadVarInt`, and related helper functions; and re-ordered `parsePerfectPacket` to invoke those helpers.  

### Testing
- No automated tests or builds were executed as part of this change.  
- The two compile errors referencing `getHexPayload` should be resolved by implementing the new getter and setting the payload from `StreamProcessor`.  
- Please run `./gradlew build` or your usual CI to verify compilation and runtime behavior after pulling these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a7717658832db0bfb703cac19889)