### PR TITLE
Handle auto-attack skill codes

### DIFF
--- a/src/main/kotlin/DpsCalculator.kt
+++ b/src/main/kotlin/DpsCalculator.kt
@@ -39,8 +39,6 @@ class DpsCalculator(private val dataStorage: DataStorage) {
     )
 
     companion object {
-        private const val AUTO_ATTACK_CODE = 1
-
         val POSSIBLE_OFFSETS: IntArray =
             intArrayOf(
                 0, 10, 20, 30, 40, 50,
@@ -57,7 +55,6 @@ class DpsCalculator(private val dataStorage: DataStorage) {
             )
 
         val SKILL_MAP = mapOf(
-            AUTO_ATTACK_CODE to "Auto Attack",
             /*
         Cleric
          */
@@ -1137,9 +1134,6 @@ class DpsCalculator(private val dataStorage: DataStorage) {
         damage: Int,
         payloadHex: String
     ): Int? {
-        if (skillCode == AUTO_ATTACK_CODE) {
-            return AUTO_ATTACK_CODE
-        }
         if (SKILL_CODES.binarySearch(skillCode) >= 0) {
             return skillCode
         }

--- a/src/main/kotlin/packet/StreamProcessor.kt
+++ b/src/main/kotlin/packet/StreamProcessor.kt
@@ -6,8 +6,6 @@ import com.tbread.entity.SpecialDamage
 import com.tbread.logging.DebugLogWriter
 import org.slf4j.LoggerFactory
 
-private const val AUTO_ATTACK_CODE = 1
-
 class StreamProcessor(private val dataStorage: DataStorage) {
     private val logger = LoggerFactory.getLogger(StreamProcessor::class.java)
 
@@ -50,22 +48,13 @@ class StreamProcessor(private val dataStorage: DataStorage) {
                     ((data[start + i + 2].toInt() and 0xFF) shl 16) or
                     ((data[start + i + 3].toInt() and 0xFF) shl 24)
                 val normalized = normalizeSkillId(raw)
-                val typeInfo = readVarInt(data, start + i + 4)
-                val isValidType = typeInfo.length > 0 && typeInfo.value in 1..9
-                if (normalized in 3_000_000..3_999_999) {
-                    if (isValidType) {
-                        offset = start + i + 4
-                        return AUTO_ATTACK_CODE
-                    }
-                }
                 if (
                     normalized in 11_000_000..19_999_999 ||
+                    normalized in 3_000_000..3_999_999 ||
                     normalized in 100_000..199_999
                 ) {
-                    if (isValidType) {
-                        offset = start + i + 4
-                        return normalized
-                    }
+                    offset = start + i + 5
+                    return normalized
                 }
             }
 


### PR DESCRIPTION
### Motivation
- Auto-attack IDs in the 3,000,000 range were being treated as regular skill IDs which caused them to be misclassified and prevented consistent labeling in DPS calculations and logs.

### Description
- Added a shared `AUTO_ATTACK_CODE` constant and mapped it to the label `"Auto Attack"` in `SKILL_MAP` via `DpsCalculator`.
- In `StreamProcessor.DamagePacketReader.readSkillCode` normalized IDs in `3_000_000..3_999_999` are now detected, the reader `offset` is advanced, and `AUTO_ATTACK_CODE` is returned instead of the raw normalized value.
- Removed the 3,000,000-range from the general acceptance branch so those IDs no longer appear as regular skill codes.
- Short-circuited `DpsCalculator.inferOriginalSkillCode` to immediately return `AUTO_ATTACK_CODE` when the inferred code equals the auto-attack sentinel.

### Testing
- No automated tests were executed for this change (per repository instructions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983e0fb41e8832d908fe0ea265cfa86)