### PR TITLE
Fix Kotlin warnings for JDK 25

### DIFF
--- a/src/main/kotlin/DpsCalculator.kt
+++ b/src/main/kotlin/DpsCalculator.kt
@@ -914,18 +914,11 @@ class DpsCalculator(private val dataStorage: DataStorage) {
         val pdpMap = dataStorage.getBossModeData()
 
         pdpMap.forEach { (target, data) ->
-            var flag = false
-            var targetInfo = targetInfoMap[target]
-            if (!targetInfoMap.containsKey(target)) {
-                flag = true
-            }
             data.forEach { pdp ->
-                if (flag) {
-                    flag = false
-                    targetInfo = TargetInfo(target, 0, pdp.getTimeStamp(), pdp.getTimeStamp())
-                    targetInfoMap[target] = targetInfo!!
+                val targetInfo = targetInfoMap.getOrPut(target) {
+                    TargetInfo(target, 0, pdp.getTimeStamp(), pdp.getTimeStamp())
                 }
-                targetInfo!!.processPdp(pdp)
+                targetInfo.processPdp(pdp)
                 //그냥 아래에서 재계산하는거 여기서 해놓고 아래에선 그냥 골라서 주는게 맞는거같은데 나중에 고민할필요있을듯
             }
         }

--- a/src/main/kotlin/config/PcapCapturerConfig.kt
+++ b/src/main/kotlin/config/PcapCapturerConfig.kt
@@ -10,7 +10,7 @@ data class PcapCapturerConfig(
     val snapshotSize: Int = 65536
 ) {
     companion object {
-        private val logger = LoggerFactory.getLogger(javaClass.enclosingClass)
+        private val logger = LoggerFactory.getLogger(PcapCapturerConfig::class.java)
         fun loadFromProperties(): PcapCapturerConfig {
             val ip = PropertyHandler.getProperty("server.ip") ?: "127.0.0.1"
             val port = PropertyHandler.getProperty("server.port") ?: "50349"

--- a/src/main/kotlin/packet/PcapCapturer.kt
+++ b/src/main/kotlin/packet/PcapCapturer.kt
@@ -14,7 +14,7 @@ class PcapCapturer(
     private val channel: Channel<CapturedPayload>
 ) {
     companion object {
-        private val logger = LoggerFactory.getLogger(javaClass.enclosingClass)
+        private val logger = LoggerFactory.getLogger(PcapCapturer::class.java)
         private const val FALLBACK_DELAY_MS = 5000L
 
         private fun getAllDevices(): List<PcapNetworkInterface> =

--- a/src/main/kotlin/packet/StreamProcessor.kt
+++ b/src/main/kotlin/packet/StreamProcessor.kt
@@ -790,9 +790,8 @@ class StreamProcessor(private val dataStorage: DataStorage) {
 
         if (reader.offset >= packet.size) return logUnparsedDamage()
 
-        val unknownInfo: VarIntOutput?
         val unknownValue = reader.tryReadVarInt() ?: return logUnparsedDamage()
-        unknownInfo = VarIntOutput(unknownValue, 1)
+        val unknownInfo = VarIntOutput(unknownValue, 1)
         val finalDamage = reader.tryReadVarInt() ?: return logUnparsedDamage()
         var adjustedDamage = finalDamage
         var multiHitCount = 0
@@ -852,7 +851,7 @@ class StreamProcessor(private val dataStorage: DataStorage) {
         pdp.setMultiHitCount(multiHitCount)
         pdp.setMultiHitDamage(multiHitDamage)
         pdp.setHealAmount(healAmount)
-        unknownInfo?.let { pdp.setUnknown(it) }
+        pdp.setUnknown(unknownInfo)
         pdp.setDamage(VarIntOutput(adjustedDamage, 1))
         pdp.setHexPayload(toHex(packet))
 

--- a/src/main/kotlin/webview/BrowserApp.kt
+++ b/src/main/kotlin/webview/BrowserApp.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.tbread.webview
 
 import com.tbread.DpsCalculator


### PR DESCRIPTION
### Motivation
- Upgrading the runtime to JDK 25 exposed Kotlin compiler warnings about unnecessary non-null assertions, improper `javaClass` usage in companions, an unnecessary safe-call on a non-null local, and deprecated `netscape.javascript.JSObject`, which were cleaned up to maintain a warning-free build.

### Description
- Simplified target-info initialization in `DpsCalculator.kt` by using `targetInfoMap.getOrPut(target)` and removed the unnecessary `!!` assertions.
- Replaced `LoggerFactory.getLogger(javaClass.enclosingClass)` with explicit class references `...::class.java` in `PcapCapturerConfig.kt` and `PcapCapturer.kt` to get the correct `Class` type.
- In `StreamProcessor.kt` collapsed the nullable `unknownInfo` handling into a single non-null local `unknownInfo` and call `pdp.setUnknown(unknownInfo)` directly to remove an unnecessary safe-call.
- Suppressed the deprecation warnings for `netscape.javascript.JSObject` in `webview/BrowserApp.kt` by adding `@file:Suppress("DEPRECATION")` at the top of the file.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69840c4f3e50832d8803da01e9a7d6c1)