### PR TITLE
Add theme support, resizable handle, and right-align settings checkboxes

### DIFF
--- a/src/main/resources/i18n/ui/en.json
+++ b/src/main/resources/i18n/ui/en.json
@@ -46,7 +46,15 @@
     "onlyMe": "Only show my character",
     "debugLogging": "Enable debug logging",
     "quit": "Quit",
-    "discord": "💬 Get support on our Discord",
+    "discord": "Get support on our Discord",
+    "theme": {
+      "label": "Theme",
+      "options": {
+        "classic": "Classic",
+        "aion2": "Aion2",
+        "ember": "Ember"
+      }
+    },
     "language": {
       "label": "Language"
     },

--- a/src/main/resources/i18n/ui/ko.json
+++ b/src/main/resources/i18n/ui/ko.json
@@ -46,7 +46,15 @@
     "onlyMe": "내 캐릭터만 표시",
     "debugLogging": "디버그 로그 활성화",
     "quit": "종료",
-    "discord": "💬 디스코드에서 지원 받기",
+    "discord": "디스코드에서 지원 받기",
+    "theme": {
+      "label": "테마",
+      "options": {
+        "classic": "클래식",
+        "aion2": "Aion2",
+        "ember": "엠버"
+      }
+    },
     "language": {
       "label": "언어"
     },

--- a/src/main/resources/i18n/ui/zh-Hans.json
+++ b/src/main/resources/i18n/ui/zh-Hans.json
@@ -46,7 +46,15 @@
     "onlyMe": "仅显示我的角色",
     "debugLogging": "启用调试日志",
     "quit": "退出",
-    "discord": "💬 在 Discord 获取支持",
+    "discord": "在 Discord 获取支持",
+    "theme": {
+      "label": "主题",
+      "options": {
+        "classic": "经典",
+        "aion2": "Aion2",
+        "ember": "余烬"
+      }
+    },
     "language": {
       "label": "语言"
     },

--- a/src/main/resources/i18n/ui/zh-Hant.json
+++ b/src/main/resources/i18n/ui/zh-Hant.json
@@ -46,7 +46,15 @@
     "onlyMe": "只顯示我的角色",
     "debugLogging": "啟用除錯記錄",
     "quit": "結束",
-    "discord": "💬 在 Discord 取得支援",
+    "discord": "在 Discord 取得支援",
+    "theme": {
+      "label": "主題",
+      "options": {
+        "classic": "經典",
+        "aion2": "Aion2",
+        "ember": "餘燼"
+      }
+    },
     "language": {
       "label": "語言"
     },

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -147,6 +147,18 @@
             </label>
             <div class="settingsRow settingsRowSelect">
               <div class="settingsInfo">
+                <div class="settingsLabel" data-i18n="settings.theme.label">Theme</div>
+              </div>
+              <select class="settingsSelect themeSelect">
+                <option value="classic" data-i18n="settings.theme.options.classic">
+                  Classic
+                </option>
+                <option value="aion2" data-i18n="settings.theme.options.aion2">Aion2</option>
+                <option value="ember" data-i18n="settings.theme.options.ember">Ember</option>
+              </select>
+            </div>
+            <div class="settingsRow settingsRowSelect">
+              <div class="settingsInfo">
                 <div class="settingsLabel" data-i18n="settings.language.label">Language</div>
               </div>
               <select class="settingsSelect languageSelect">
@@ -185,8 +197,18 @@
                 <span data-i18n="settings.debugLogging">Enable debug logging</span>
               </label>
             </div>
-            <button class="discordButton" data-i18n="settings.discord">
-              💬 Get support on our Discord
+            <button class="discordButton" type="button">
+              <span data-i18n="settings.discord">Get support on our Discord</span>
+              <span class="discordIcon" aria-hidden="true">
+                <svg
+                  viewBox="0 0 24 24"
+                  role="img"
+                  focusable="false"
+                  aria-hidden="true">
+                  <path
+                    d="M19.75 4.94A19.87 19.87 0 0 0 15.32 3a13.4 13.4 0 0 0-.64 1.3 18.5 18.5 0 0 0-5.35 0A13.4 13.4 0 0 0 8.68 3a19.9 19.9 0 0 0-4.43 1.94C2.2 8.17 1.7 11.29 1.95 14.37A19.7 19.7 0 0 0 7 17.04c.42-.57.8-1.18 1.13-1.82-.62-.23-1.2-.52-1.75-.85.15-.1.3-.2.45-.3 3.38 1.56 7.05 1.56 10.42 0 .15.1.3.2.45.3-.54.33-1.13.62-1.75.85.33.64.71 1.25 1.13 1.82a19.7 19.7 0 0 0 5.04-2.67c.34-3.68-.55-6.77-2.37-9.31ZM8.9 12.9c-.77 0-1.4-.71-1.4-1.58 0-.87.62-1.58 1.4-1.58.78 0 1.4.7 1.4 1.58 0 .87-.62 1.58-1.4 1.58Zm6.2 0c-.77 0-1.4-.71-1.4-1.58 0-.87.62-1.58 1.4-1.58.78 0 1.4.7 1.4 1.58 0 .87-.62 1.58-1.4 1.58Z" />
+                </svg>
+              </span>
             </button>
             <button class="quitButton" data-i18n="settings.quit">Quit</button>
           </div>
@@ -199,6 +221,7 @@
             Ready - monitoring combat...
           </div>
         </div>
+        <div class="resizeHandle" aria-hidden="true"></div>
       </div>
       <div
         class="console"

--- a/src/main/resources/js/meter.js
+++ b/src/main/resources/js/meter.js
@@ -1,5 +1,6 @@
 const createMeterUI = ({ elList, dpsFormatter, getUserName, onClickUserRow, getMetric }) => {
   const MAX_CACHE = 32;
+  const cjkRegex = /[\u3400-\u9FFF\uF900-\uFAFF]/;
 
   const rowViewById = new Map();
   let lastVisibleIds = new Set();
@@ -153,10 +154,12 @@ const createMeterUI = ({ elList, dpsFormatter, getUserName, onClickUserRow, getM
       view.rowEl.classList.toggle("isIdentifying", !!row.isIdentifying);
 
       const rowId = row.id ?? row.name ?? "";
-      view.nameEl.textContent = row.isIdentifying
+      const nameText = row.isIdentifying
         ? window.i18n?.format?.("meter.identifyingPlayer", { id: rowId }, `Player #${rowId}`) ??
           `Player #${rowId}`
         : row.name ?? "";
+      view.nameEl.textContent = nameText;
+      view.nameEl.classList.toggle("isCjk", cjkRegex.test(nameText));
       if (row.job && !!row.job) {
         const src = `./assets/${row.job}.png`;
         view.classIconImg.src = src;

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -4,11 +4,15 @@
   --warning-fill: #ffa537;
   --error-fill: #c24343;
   --dps: #29ff6f;
+  --dps-text: #f0fff0;
 
   --text-color: rgb(255, 255, 255);
   --text-shadow:
-          0 1px 2px rgba(0, 0, 0, 0.8),
-          0 2px 8px rgba(0, 0, 0, 0.4);
+          0 0 1px rgba(0, 0, 0, 0.95),
+          0 1px 1px rgba(0, 0, 0, 0.95),
+          0 2px 3px rgba(0, 0, 0, 0.8),
+          0 4px 10px rgba(0, 0, 0, 0.45),
+          0 0 6px rgba(124, 77, 255, 0.25);
 
   --rounded-lg: 12px;
   --rounded: 10px;
@@ -19,6 +23,28 @@
   --title: rgba(235, 245, 255, 0.95);
   --font: 16px;
   --details-bg-opacity: 0.5;
+}
+
+:root[data-theme="aion2"] {
+  --row-fill: #5b4dff;
+  --isUser-fill: #36c5ff;
+  --warning-fill: #ffae4f;
+  --error-fill: #ff5a7a;
+  --dps: #29ff6f;
+  --dps-text: #7fd8ff;
+  --panel-border: rgba(140, 180, 255, 0.2);
+  --title: rgba(220, 235, 255, 0.98);
+}
+
+:root[data-theme="ember"] {
+  --row-fill: #ff9a3d;
+  --isUser-fill: #ff6b6b;
+  --warning-fill: #ffd166;
+  --error-fill: #ff3b5c;
+  --dps: #29ff6f;
+  --dps-text: #ffd7a3;
+  --panel-border: rgba(255, 210, 165, 0.2);
+  --title: rgba(255, 240, 220, 0.98);
 }
 
 * {
@@ -56,6 +82,9 @@
   /* background-color: rgba(255, 255, 255, 0.1); */
   border: 1px solid rgba(209, 213, 219, 0.3);
   border-radius: var(--rounded);
+  position: relative;
+  min-width: 300px;
+  min-height: 160px;
 }
 
 .header {
@@ -231,6 +260,8 @@
     align-items: center;
     gap: 8px;
     font-size: 13px;
+    justify-content: flex-end;
+    width: 100%;
   }
 
   .discordButton {
@@ -243,6 +274,22 @@
     text-shadow: var(--text-shadow);
     width: 100%;
     text-align: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+
+  .discordButton .discordIcon {
+    display: inline-flex;
+    width: 20px;
+    height: 20px;
+  }
+
+  .discordButton .discordIcon svg {
+    width: 100%;
+    height: 100%;
+    fill: currentColor;
   }
 
   .quitButton {
@@ -329,10 +376,10 @@
       text-overflow: ellipsis;
     }
     .dps {
-      color: var(--dps);
+      color: var(--dps-text);
       font-size: var(--font);
       text-shadow: var(--text-shadow);
-      font-weight: bold;
+      font-weight: 400;
       display: flex;
       align-items: center;
       gap: 8px;
@@ -340,8 +387,8 @@
   }
 }
 .meter .item.isIdentifying .content .name {
-  font-size: 14px;
-  font-weight: 500;
+  font-size: 18px;
+  font-weight: 400;
 }
 .battleTime {
   display: none;
@@ -390,6 +437,27 @@
   }
 }
 
+.resizeHandle {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  width: 14px;
+  height: 14px;
+  cursor: se-resize;
+  opacity: 0.65;
+}
+
+.resizeHandle::before {
+  content: "";
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid rgba(255, 255, 255, 0.7);
+  border-bottom: 2px solid rgba(255, 255, 255, 0.7);
+}
+
 .detailsPanel {
   position: absolute;
   color: white;
@@ -400,7 +468,7 @@
   /* top: calc(100% + 4px); */
   top: 0;
   font-weight: bold;
-  width: 864px;
+  width: 920px;
   border: 1px solid var(--panel-border);
   background: rgba(12, 22, 40, var(--details-bg-opacity, 0.5));
   padding: 6px 4px;
@@ -616,7 +684,8 @@
             justify-content: end;
             align-items: center;
             text-shadow: var(--text-shadow);
-            color: var(--dps);
+            color: var(--dps-text);
+            font-weight: 400;
           }
         }
       }
@@ -805,6 +874,20 @@
   text-shadow: var(--text-shadow);
   width: 100%;
   text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+.settingsPanel .discordButton .discordIcon {
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
+}
+.settingsPanel .discordButton .discordIcon svg {
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
 }
 
 .list .item {
@@ -861,11 +944,14 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+.list .item .name.isCjk {
+  font-weight: 500;
+}
 .list .item .dps {
-  color: var(--dps);
+  color: var(--dps-text);
   font-size: var(--font);
   text-shadow: var(--text-shadow);
-  font-weight: bold;
+  font-weight: 400;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -1089,7 +1175,8 @@
   justify-content: end;
   align-items: center;
   text-shadow: var(--text-shadow);
-  color: var(--dps);
+  color: var(--dps-text);
+  font-weight: 400;
 }
 
 .updateModal.isOpen {


### PR DESCRIPTION
### Motivation
- Improve settings UX by right-aligning the `Only show my character` and `Enable debug logging` controls inside the settings panel. 
- Provide simple theme options to let users pick a visual palette and persist the choice. 
- Make the meter window resizable with a dedicated handle while avoiding conflicts with the existing drag-to-move behavior and improve CJK name rendering.

### Description
- Update `src/main/resources/styles.css` to right-align `.settingsCheckbox`, add `--dps-text` and an expanded `--text-shadow`, add theme variable roots for `aion2` and `ember`, add `.resizeHandle` styling, and adjust layout minimum sizes and button/icon styles. 
- Modify `src/main/resources/index.html` to add a theme `select` control, remove the emoji from the Discord button text, include an inline Discord SVG icon, and insert the `.resizeHandle` element. 
- Extend `src/main/resources/js/core.js` to add `theme` to `storageKeys`, expose `availableThemes`, implement `applyTheme(themeId, { persist })`, bind the theme selector, call `bindResizeHandle()` on startup, and add `bindResizeHandle()` that implements mouse-driven resize logic and prevents drag-to-move when interacting with the resize handle. 
- Update `src/main/resources/js/meter.js` to detect CJK characters (`cjkRegex`) and toggle an `isCjk` class for name rendering to improve typographic weight. 
- Update i18n files under `src/main/resources/i18n/ui/*.json` to remove the Discord emoji and add `settings.theme` translations for supported languages.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698429463140832dae9907d88ae6d55a)