### PR TITLE
Add 'Pin Me To Top' setting and convert settings checkboxes to toggles

### DIFF
--- a/src/main/resources/i18n/ui/en.json
+++ b/src/main/resources/i18n/ui/en.json
@@ -49,6 +49,7 @@
     "resetDetection": "Reset detection",
     "characterName": "Character name",
     "characterNamePlaceholder": "Enter your character name",
+    "pinMeToTop": "Pin Me To Top",
     "debugLogging": "Enable debug logging",
     "quit": "Quit",
     "discord": "Get support on our Discord",

--- a/src/main/resources/i18n/ui/ko.json
+++ b/src/main/resources/i18n/ui/ko.json
@@ -49,6 +49,7 @@
     "resetDetection": "감지 초기화",
     "characterName": "캐릭터 이름",
     "characterNamePlaceholder": "캐릭터 이름 입력",
+    "pinMeToTop": "내 캐릭터를 맨 위에 고정",
     "debugLogging": "디버그 로그 활성화",
     "quit": "종료",
     "discord": "디스코드에서 지원 받기",

--- a/src/main/resources/i18n/ui/zh-Hans.json
+++ b/src/main/resources/i18n/ui/zh-Hans.json
@@ -49,6 +49,7 @@
     "resetDetection": "重置检测",
     "characterName": "角色名称",
     "characterNamePlaceholder": "输入你的角色名称",
+    "pinMeToTop": "将我置顶",
     "debugLogging": "启用调试日志",
     "quit": "退出",
     "discord": "在 Discord 获取支持",

--- a/src/main/resources/i18n/ui/zh-Hant.json
+++ b/src/main/resources/i18n/ui/zh-Hant.json
@@ -49,6 +49,7 @@
     "resetDetection": "重置偵測",
     "characterName": "角色名稱",
     "characterNamePlaceholder": "輸入你的角色名稱",
+    "pinMeToTop": "將我置頂",
     "debugLogging": "啟用除錯記錄",
     "quit": "結束",
     "discord": "在 Discord 取得支援",

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -250,11 +250,25 @@
               </div>
             </div>
             <div>
-              <label class="settingsCheckbox">
-                <input
-                        type="checkbox"
-                        class="debugLoggingCheckbox" />
-                <span data-i18n="settings.debugLogging">Enable debug logging</span>
+              <label class="settingsToggle">
+                <span class="settingsToggleLabel" data-i18n="settings.pinMeToTop">
+                  Pin Me To Top
+                </span>
+                <span class="settingsToggleControl">
+                  <input type="checkbox" class="pinMeToTopCheckbox" />
+                  <span class="settingsToggleTrack" aria-hidden="true"></span>
+                </span>
+              </label>
+            </div>
+            <div>
+              <label class="settingsToggle">
+                <span class="settingsToggleLabel" data-i18n="settings.debugLogging">
+                  Enable debug logging
+                </span>
+                <span class="settingsToggleControl">
+                  <input type="checkbox" class="debugLoggingCheckbox" />
+                  <span class="settingsToggleTrack" aria-hidden="true"></span>
+                </span>
               </label>
             </div>
             <button class="discordButton" type="button">

--- a/src/main/resources/js/core.js
+++ b/src/main/resources/js/core.js
@@ -7,6 +7,7 @@ class DpsApp {
     this.USER_NAME = "";
     this.onlyShowUser = false;
     this.debugLoggingEnabled = false;
+    this.pinMeToTop = false;
     this.storageKeys = {
       userName: "dpsMeter.userName",
       onlyShowUser: "dpsMeter.onlyShowUser",
@@ -17,6 +18,7 @@ class DpsApp {
       displayMode: "dpsMeter.displayMode",
       language: "dpsMeter.language",
       debugLogging: "dpsMeter.debugLoggingEnabled",
+      pinMeToTop: "dpsMeter.pinMeToTop",
       theme: "dpsMeter.theme",
       refreshKeybind: "dpsMeter.refreshKeybind",
     };
@@ -141,6 +143,7 @@ class DpsApp {
       getUserName: () => this.USER_NAME,
       getMetric: (row) => this.getMetricForRow(row),
       getSortDirection: () => this.listSortDirection,
+      getPinUserToTop: () => this.pinMeToTop,
       onClickUserRow: (row) =>
         this.detailsUI.open(row, {
           defaultTargetAll: this.lastTargetMode === "allTargets",
@@ -890,6 +893,7 @@ class DpsApp {
     this.resetDetectBtn = document.querySelector(".resetDetectBtn");
     this.characterNameInput = document.querySelector(".characterNameInput");
     this.debugLoggingCheckbox = document.querySelector(".debugLoggingCheckbox");
+    this.pinMeToTopCheckbox = document.querySelector(".pinMeToTopCheckbox");
     this.discordButton = document.querySelector(".discordButton");
     this.quitButton = document.querySelector(".quitButton");
     this.languageDropdownBtn = document.querySelector(".languageDropdownBtn");
@@ -912,6 +916,7 @@ class DpsApp {
       this.safeGetStorage(this.storageKeys.trainSelectionMode) ||
       "all";
     const storedDebugLogging = this.safeGetSetting(this.storageKeys.debugLogging) === "true";
+    const storedPinMeToTop = this.safeGetSetting(this.storageKeys.pinMeToTop) === "true";
     const storedTargetSelection = this.safeGetStorage(this.storageKeys.targetSelection);
     const storedLanguage = this.safeGetStorage(this.storageKeys.language);
     const storedTheme = this.safeGetSetting(this.storageKeys.theme);
@@ -922,6 +927,7 @@ class DpsApp {
     this.setUserName(storedName, { persist: false, syncBackend: true });
     this.setOnlyShowUser(false, { persist: false });
     this.setDebugLogging(storedDebugLogging, { persist: false, syncBackend: true });
+    this.setPinMeToTop(storedPinMeToTop, { persist: false });
     const normalizedTargetSelection =
       storedTargetSelection === "allTargets" || storedTargetSelection === "trainTargets"
         ? storedTargetSelection
@@ -979,6 +985,13 @@ class DpsApp {
       this.debugLoggingCheckbox.addEventListener("change", (event) => {
         const isChecked = !!event.target?.checked;
         this.setDebugLogging(isChecked, { persist: true, syncBackend: true });
+      });
+    }
+    if (this.pinMeToTopCheckbox) {
+      this.pinMeToTopCheckbox.checked = this.pinMeToTop;
+      this.pinMeToTopCheckbox.addEventListener("change", (event) => {
+        const isChecked = !!event.target?.checked;
+        this.setPinMeToTop(isChecked, { persist: true });
       });
     }
 
@@ -1478,6 +1491,17 @@ class DpsApp {
     if (syncBackend) {
       window.javaBridge?.setDebugLoggingEnabled?.(this.debugLoggingEnabled);
     }
+  }
+
+  setPinMeToTop(enabled, { persist = false } = {}) {
+    this.pinMeToTop = !!enabled;
+    if (this.pinMeToTopCheckbox && document.activeElement !== this.pinMeToTopCheckbox) {
+      this.pinMeToTopCheckbox.checked = this.pinMeToTop;
+    }
+    if (persist) {
+      this.safeSetSetting(this.storageKeys.pinMeToTop, String(this.pinMeToTop));
+    }
+    this.renderCurrentRows();
   }
 
   setTargetSelection(mode, { persist = false, syncBackend = false, reason = "update" } = {}) {

--- a/src/main/resources/js/meter.js
+++ b/src/main/resources/js/meter.js
@@ -1,4 +1,12 @@
-const createMeterUI = ({ elList, dpsFormatter, getUserName, onClickUserRow, getMetric, getSortDirection }) => {
+const createMeterUI = ({
+  elList,
+  dpsFormatter,
+  getUserName,
+  onClickUserRow,
+  getMetric,
+  getSortDirection,
+  getPinUserToTop,
+}) => {
   const MAX_CACHE = 32;
   const cjkRegex = /[\u3400-\u9FFF\uF900-\uFAFF]/;
 
@@ -87,6 +95,10 @@ const createMeterUI = ({ elList, dpsFormatter, getUserName, onClickUserRow, getM
     const user = sortedAll.find((x) => x.isUser);
 
     if (!user) return top6;
+    const pinUser = typeof getPinUserToTop === "function" && getPinUserToTop();
+    if (pinUser) {
+      return [user, ...top6.filter((row) => !row.isUser)];
+    }
     if (top6.some((x) => x.isUser)) return top6;
     return [...top6, user];
   };

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -438,13 +438,70 @@ html[lang="ko"] * {
     outline-offset: 1px;
   }
 
-  .settingsCheckbox {
+  .settingsToggle {
     display: flex;
     align-items: center;
-    gap: 8px;
+    justify-content: space-between;
+    gap: 12px;
     font-size: 13px;
-    justify-content: flex-end;
     width: 100%;
+  }
+
+  .settingsToggleLabel {
+    flex: 1;
+    text-align: left;
+  }
+
+  .settingsToggleControl {
+    position: relative;
+    width: 36px;
+    height: 20px;
+    flex-shrink: 0;
+  }
+
+  .settingsToggleControl input[type="checkbox"] {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+    margin: 0;
+  }
+
+  .settingsToggleTrack {
+    position: absolute;
+    inset: 0;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.2);
+    border: 1px solid var(--panel-border);
+    transition: background 0.2s ease, border-color 0.2s ease;
+  }
+
+  .settingsToggleTrack::after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #fff;
+    transition: transform 0.2s ease;
+  }
+
+  .settingsToggleControl input[type="checkbox"]:checked + .settingsToggleTrack {
+    background: var(--isUser-fill);
+    border-color: var(--isUser-fill);
+  }
+
+  .settingsToggleControl input[type="checkbox"]:checked + .settingsToggleTrack::after {
+    transform: translateX(16px);
+  }
+
+  .settingsToggleControl input[type="checkbox"]:focus-visible + .settingsToggleTrack {
+    outline: 2px solid var(--isUser-fill);
+    outline-offset: 2px;
   }
 
   .discordButton {
@@ -1340,10 +1397,10 @@ html[lang="ko"] * {
   background: rgba(255, 255, 255, 0.08);
 }
 
-.settingsPanel .settingsCheckbox {
+.settingsPanel .settingsToggle {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   font-size: 13px;
 }
 .settingsPanel .discordButton {


### PR DESCRIPTION
### Motivation
- Provide an option in Meter Settings to keep the local player's row visually pinned to the top of the meter list rather than being ordered with others. 
- Improve the settings UI by replacing checkbox controls with modern toggle switches for better clarity and accessibility.

### Description
- UI: Added a new `Pin Me To Top` toggle in `src/main/resources/index.html` and converted the existing debug-logging checkbox markup into the new toggle layout. 
- Styling: Replaced `.settingsCheckbox` usage with a `.settingsToggle` style and added toggle control/track styles in `src/main/resources/styles.css`. 
- Behavior: Wired a persistent `pinMeToTop` setting into `src/main/resources/js/core.js` including a storage key, restore logic, `setPinMeToTop` setter, and event listener for the new checkbox. 
- Meter ordering: Updated `src/main/resources/js/meter.js` to accept a `getPinUserToTop` callback and, when enabled, render the local player row at the top of the displayed list. 
- Localization: Added `pinMeToTop` labels to supported language files under `src/main/resources/i18n/ui/` (en, ko, zh-Hans, zh-Hant).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985b35c1e34833388214579375aa093)