### PR TITLE
Prefer capture device with fewer magic flow candidates

### DIFF
--- a/src/main/kotlin/packet/CaptureDispatcher.kt
+++ b/src/main/kotlin/packet/CaptureDispatcher.kt
@@ -39,7 +39,7 @@ class CaptureDispatcher(
             // "Lock" is informational for now; don't filter until parsing confirmed stable
             if (CombatPortDetector.currentPort() == null && isUnencryptedCandidate(cap.data)) {
                 // Choose srcPort for now (since magic typically comes from the sender)
-                CombatPortDetector.registerCandidate(cap.srcPort, cap.deviceName)
+                CombatPortDetector.registerCandidate(cap.srcPort, key, cap.deviceName)
                 logger.info(
                     "Magic seen on flow {}-{} (src={}, dst={}, device={})",
                     a,


### PR DESCRIPTION
### Motivation
- Combat port detection sometimes locked to a device with many matching flows (e.g. the Intel NIC) instead of preferring loopback-style adapters that had a single matching flow, so the detector should prefer devices with fewer distinct flow candidates.

### Description
- Track per-device sets of observed magic flow keys via a new `deviceFlows` map in `CombatPortDetector` and record flow keys when registering candidates.
- Change `registerCandidate` to accept a flow key (`Pair<Int,Int>`) and update `CaptureDispatcher` to pass the `key` when reporting magic sightings.
- Defer locking in `confirmCandidate` when another device has strictly fewer distinct flow candidates and log the deferral instead of immediately calling `lock`.
- Clear `deviceFlows` alongside `candidates` in `lock`, `clearCandidates`, and `reset` to keep state consistent.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985c536970883339308f8551aa087d5)