### PR TITLE
Keep CJK (Chinese) names normal weight in meter lines

### DIFF
--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -761,6 +761,9 @@ html[lang="ko"] * {
       white-space: nowrap;
       text-overflow: ellipsis;
     }
+    .name.isCjk {
+      font-weight: 400;
+    }
     .dps {
       color: var(--dps-text);
       font-size: var(--font);


### PR DESCRIPTION
### Motivation
- CJK (Chinese) player names were being rendered bold in meter rows because the meter name style used a heavier font weight, so add an override to keep CJK names at normal weight.

### Description
- Add a CSS override `.name.isCjk { font-weight: 400; }` in `src/main/resources/styles.css` to ensure names flagged as CJK are not bold in the meter content.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ec72be708333a4a124b0d62b10cc)