### PR TITLE
Fix refresh behavior: keep status visible and prevent stale meters from repopulating

### DIFF
--- a/src/main/resources/i18n/ui/en.json
+++ b/src/main/resources/i18n/ui/en.json
@@ -17,7 +17,14 @@
     },
     "panelBackground": "Panel background",
     "screenshot": {
-      "captured": "Captured Screenshot"
+      "ariaLabel": "Save screenshot to clipboard",
+      "captured": "Captured Screenshot",
+      "savedToClipboard": "Saved to clipboard"
+    },
+    "sort": {
+      "recent": "Recent",
+      "time": "Time",
+      "damage": "Damage"
     },
     "skills": {
       "skill": "Skill",

--- a/src/main/resources/i18n/ui/ko.json
+++ b/src/main/resources/i18n/ui/ko.json
@@ -17,7 +17,14 @@
     },
     "panelBackground": "패널 배경",
     "screenshot": {
-      "captured": "스크린샷 캡처됨"
+      "ariaLabel": "클립보드에 스크린샷 저장",
+      "captured": "스크린샷 캡처됨",
+      "savedToClipboard": "클립보드에 저장됨"
+    },
+    "sort": {
+      "recent": "최근",
+      "time": "시간",
+      "damage": "피해"
     },
     "skills": {
       "skill": "스킬",

--- a/src/main/resources/i18n/ui/zh-Hans.json
+++ b/src/main/resources/i18n/ui/zh-Hans.json
@@ -17,7 +17,14 @@
     },
     "panelBackground": "面板背景",
     "screenshot": {
-      "captured": "已捕获截图"
+      "ariaLabel": "将截图保存到剪贴板",
+      "captured": "已捕获截图",
+      "savedToClipboard": "已保存到剪贴板"
+    },
+    "sort": {
+      "recent": "最近",
+      "time": "时间",
+      "damage": "伤害"
     },
     "skills": {
       "skill": "技能",

--- a/src/main/resources/i18n/ui/zh-Hant.json
+++ b/src/main/resources/i18n/ui/zh-Hant.json
@@ -17,7 +17,14 @@
     },
     "panelBackground": "面板背景",
     "screenshot": {
-      "captured": "已擷取截圖"
+      "ariaLabel": "將截圖儲存到剪貼簿",
+      "captured": "已擷取截圖",
+      "savedToClipboard": "已儲存到剪貼簿"
+    },
+    "sort": {
+      "recent": "最近",
+      "time": "時間",
+      "damage": "傷害"
     },
     "skills": {
       "skill": "技能",

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -77,11 +77,21 @@
               </div>
               <span class="detailsTargetSuffix"></span>
               <div class="detailsTargetSort">
-                <button class="detailsSortBtn" data-sort="recent" type="button">Recent</button>
-                <button class="detailsSortBtn" data-sort="time" type="button">Time</button>
-                <button class="detailsSortBtn" data-sort="damage" type="button">Damage</button>
+                <button class="detailsSortBtn" data-sort="recent" type="button" data-i18n="details.sort.recent">
+                  Recent
+                </button>
+                <button class="detailsSortBtn" data-sort="time" type="button" data-i18n="details.sort.time">
+                  Time
+                </button>
+                <button class="detailsSortBtn" data-sort="damage" type="button" data-i18n="details.sort.damage">
+                  Damage
+                </button>
               </div>
-              <button class="detailsScreenshotBtn" type="button" aria-label="Save screenshot to clipboard">
+              <button
+                class="detailsScreenshotBtn"
+                type="button"
+                aria-label="Save screenshot to clipboard"
+                data-i18n-aria-label="details.screenshot.ariaLabel">
                 <i data-lucide="camera"></i>
               </button>
               <span class="detailsScreenshotNote" aria-live="polite"></span>

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -21,10 +21,10 @@
 
   /* Stronger, “always readable” DPS shadow */
   --dps-shadow:
-          0 0 1px rgba(0,0,0,0.94),
-          0 1px 2px rgba(0,0,0,0.72),
-          0 2px 6px rgba(0,0,0,0.48),
-          0 0 10px var(--panel-border);
+          0 0 1px rgba(0,0,0,0.96),
+          0 1px 2px rgba(0,0,0,0.78),
+          0 2px 8px rgba(0,0,0,0.58),
+          0 0 12px var(--panel-border);
 
   /* Player name / primary label shadow (Ember-grade readability) */
   --player-name-shadow:
@@ -154,10 +154,10 @@
     0 6px 14px rgba(176,100,255,0.24);
 
   --dps-shadow:
-    0 0 1px rgba(0,0,0,0.92),
-    0 1px 2px rgba(0,0,0,0.72),
-    0 2px 8px rgba(0,0,0,0.50),
-    0 0 12px rgba(176,100,255,0.30);
+    0 0 1px rgba(0,0,0,0.96),
+    0 1px 2px rgba(0,0,0,0.80),
+    0 2px 8px rgba(0,0,0,0.60),
+    0 0 14px rgba(176,100,255,0.36);
 }
 
 :root[data-theme="varian"] {
@@ -180,10 +180,10 @@
     0 6px 14px rgba(255,224,98,0.22);
 
   --dps-shadow:
-    0 0 1px rgba(0,0,0,0.94),
-    0 1px 2px rgba(0,0,0,0.76),
-    0 2px 8px rgba(0,0,0,0.45),
-    0 0 8px rgba(255,230,140,0.22);
+    0 0 1px rgba(0,0,0,0.96),
+    0 1px 2px rgba(0,0,0,0.82),
+    0 2px 8px rgba(0,0,0,0.55),
+    0 0 10px rgba(255,230,140,0.30);
 
   --player-name-shadow:
     -1px  0   0 rgba(0,0,0,0.92),
@@ -236,10 +236,10 @@
     0 0 10px rgba(140,200,255,0.28);
 
   --dps-shadow:
-    0 0 1px rgba(0,0,0,0.92),
-    0 1px 2px rgba(0,0,0,0.74),
-    0 2px 8px rgba(0,0,0,0.50),
-    0 0 12px rgba(107,188,255,0.40);
+    0 0 1px rgba(0,0,0,0.95),
+    0 1px 2px rgba(0,0,0,0.82),
+    0 2px 8px rgba(0,0,0,0.60),
+    0 0 14px rgba(107,188,255,0.48);
 
   --player-name-shadow:
     -1px  0   0 rgba(0,0,0,0.90),
@@ -259,6 +259,21 @@
   --dps-text: #f5f5f5;
   --panel-border: rgba(200, 200, 200, 0.18);
   --title: rgba(245, 245, 245, 0.98);
+}
+
+@keyframes detailsFlash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.0);
+    border-color: var(--panel-border);
+  }
+  35% {
+    box-shadow: 0 0 18px 2px rgba(255, 255, 255, 0.35);
+    border-color: rgba(255, 255, 255, 0.6);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.0);
+    border-color: var(--panel-border);
+  }
 }
 
 * {
@@ -866,6 +881,10 @@ html[lang="ko"] * {
   background: rgba(12, 22, 40, var(--details-bg-opacity, 0.5));
   padding: 6px 4px;
   border-radius: var(--rounded-lg);
+
+  &.flash {
+    animation: detailsFlash 1s ease-out;
+  }
 
   &.open {
     display: block;


### PR DESCRIPTION
### Motivation
- Avoid a UX issue where clicking refresh briefly clears the meters but they immediately reappear due to stale data from the backend, and ensure the battle-time/status messaging remains visible while a refresh is in progress.

### Description
- Add a `refreshPending` flag to `DpsApp` to track manual refresh state and prevent stale payloads from repopulating the meter while awaiting backend reset by introducing `this.refreshPending` and setting it in `refreshDamageData` (`src/main/resources/js/core.js`).
- Make `fetchDps` respect the refresh guard by skipping re-render when `raw === this.lastJson` while refreshing, and by acknowledging an empty payload as the reset completion to clear `refreshPending` and keep the meters cleared (`src/main/resources/js/core.js`).
- Stop clearing battle-time / status UI during `refreshDamageData` so the status message and icon remain visible while the refresh completes (`src/main/resources/js/core.js`).
- Improve Details panel screenshot UX by adding a brief flash animation and a screenshot note: add `screenshotFlashTimer` logic and toggle a `flash` class on the details panel (`src/main/resources/js/core.js`).
- Add i18n keys and wire HTML attributes for screenshot ARIA text and details sort buttons (`src/main/resources/i18n/*`, `src/main/resources/index.html`).
- Add the `detailsFlash` keyframes and `.detailsPanel.flash` animation and a few CSS refinements (`src/main/resources/styles.css`).

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f0cd5b08833387edfb8e519164eb)