### PR TITLE
Honor Training Mode target when opening Details

### DIFF
--- a/src/main/resources/js/core.js
+++ b/src/main/resources/js/core.js
@@ -165,8 +165,16 @@ class DpsApp {
           this.lastTargetMode === "lastHitByMe" &&
           (!Number(this.lastTargetId) || Number(this.lastTargetId) <= 0) &&
           !this.lastTargetName;
+        const isTrainTargets = this.lastTargetMode === "trainTargets";
+        const shouldDefaultAllTrainTargets = isTrainTargets && this.trainSelectionMode === "all";
+        const shouldDefaultTrainTarget = isTrainTargets && this.trainSelectionMode === "highestDamage";
+        const defaultTargetId = shouldDefaultTrainTarget && Number(this.lastTargetId) > 0
+          ? Number(this.lastTargetId)
+          : null;
         this.detailsUI.open(row, {
-          defaultTargetAll: this.lastTargetMode === "allTargets" || fallbackAllTargets,
+          defaultTargetAll:
+            this.lastTargetMode === "allTargets" || fallbackAllTargets || shouldDefaultAllTrainTargets,
+          defaultTargetId,
         });
       },
     });

--- a/src/main/resources/js/details.js
+++ b/src/main/resources/js/details.js
@@ -897,7 +897,10 @@ const createDetailsUI = ({
 
   const isOpen = () => detailsPanel.classList.contains("open");
 
-  const open = async (row, { force = false, restartOnSwitch = true, defaultTargetAll = false } = {}) => {
+  const open = async (
+    row,
+    { force = false, restartOnSwitch = true, defaultTargetAll = false, defaultTargetId = null } = {}
+  ) => {
     const rowId = row?.id ?? null;
     // if (!rowId) return;
 
@@ -924,6 +927,8 @@ const createDetailsUI = ({
     loadDetailsContext();
     if (defaultTargetAll) {
       selectedTargetId = null;
+    } else if (Number.isFinite(Number(defaultTargetId)) && Number(defaultTargetId) > 0) {
+      selectedTargetId = Number(defaultTargetId);
     } else if (detailsContext && detailsContext.currentTargetId) {
       selectedTargetId = detailsContext.currentTargetId;
     } else {


### PR DESCRIPTION
### Motivation
- Ensure the details panel respects the Training Mode target selection so clicking a meter row opens details filtered by either all mobs or the currently-locked training target depending on the user setting.

### Description
- Update `createMeterUI` click handler in `src/main/resources/js/core.js` to detect when `lastTargetMode === "trainTargets"` and compute `defaultTargetAll` for the `all` trainSelectionMode and `defaultTargetId` for the `highestDamage` trainSelectionMode, then pass these into `detailsUI.open`.
- Extend the `open` API in `src/main/resources/js/details.js` to accept a `defaultTargetId` parameter and apply it before rendering so the details view opens with the requested target selection.
- No changes to server/backend logic; the patch only adjusts how the UI decides and passes the default details target.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875b008b4c8333996f2c9909c6fac6)