### PR TITLE
Force Prism software rendering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -179,6 +179,7 @@ compose.desktop {
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+UseCompactObjectHeaders",
             "--add-opens=java.base/java.nio=ALL-UNNAMED",
+            "-Dprism.order=sw",
             // We removed the --add-modules here.
             // JavaFX will load from the classpath as 'unnamed' modules.
             "-Dapple.laf.useScreenMenuBar=true"


### PR DESCRIPTION
### Motivation
- Ensure JavaFX Prism uses software rendering to avoid GPU/driver issues on systems without proper hardware acceleration.

### Description
- Add the JVM flag `-Dprism.order=sw` to the `jvmArgs` in `compose.desktop` within `build.gradle.kts` so the desktop app forces software rendering.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d4f60bd48333b1a6213fc9877efd)