### PR TITLE
Prefer loopback traffic after combat port lock

### DIFF
--- a/src/main/kotlin/packet/CaptureDispatcher.kt
+++ b/src/main/kotlin/packet/CaptureDispatcher.kt
@@ -30,6 +30,10 @@ class CaptureDispatcher(
                 if (!ensureAionRunning()) {
                     continue
                 }
+                val lockedDevice = CombatPortDetector.currentDevice()
+                if (lockedDevice != null && !deviceMatches(lockedDevice, cap.deviceName)) {
+                    continue
+                }
                 val a = minOf(cap.srcPort, cap.dstPort)
                 val b = maxOf(cap.srcPort, cap.dstPort)
                 val key = a to b
@@ -109,6 +113,11 @@ class CaptureDispatcher(
             if (ok) return true
         }
         return false
+    }
+
+    private fun deviceMatches(lockedDevice: String, packetDevice: String?): Boolean {
+        val trimmedPacket = packetDevice?.trim()?.takeIf { it.isNotBlank() } ?: return false
+        return trimmedPacket.equals(lockedDevice, ignoreCase = true)
     }
 
     fun getParsingBacklog(): Int {


### PR DESCRIPTION
### Motivation
- Users running network multiplexers like Exitlag can produce multiple device-level flows for the same game traffic which causes duplicate parsing when the detector locks to a non-loopback adapter.
- The change aims to prefer a loopback capture when it becomes available for the same locked port and to avoid parsing packets from other adapters once a device is selected.

### Description
- Added `promoteLoopback(port, deviceName)` to `CombatPortDetector` to switch the locked device to a loopback interface when the same locked port also appears on loopback, with informational logging.
- Updated `registerCandidate` in `CombatPortDetector` to call `promoteLoopback` when a port is already locked so loopback can replace a prior non-loopback lock for the same port.
- Modified `CaptureDispatcher.run` to drop incoming `CapturedPayload` entries that do not match the currently locked device by checking `CombatPortDetector.currentDevice()` and added a `deviceMatches` helper to do the comparison.
- Added small log messages to indicate the device switch and preserved existing behavior of delaying filtering until parsing is confirmed stable.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988deb29a308333bc023e1c7ce744e3)