### PR TITLE
Improve capture device detection & logging; add force-loopback UI and prelock logging

### DIFF
--- a/src/main/kotlin/packet/PacketCaptureStatus.kt
+++ b/src/main/kotlin/packet/PacketCaptureStatus.kt
@@ -1,0 +1,11 @@
+package com.tbread.packet
+
+object PacketCaptureStatus {
+    @Volatile private var npcapAvailable: Boolean = true
+
+    fun setNpcapAvailable(available: Boolean) {
+        npcapAvailable = available
+    }
+
+    fun isNpcapAvailable(): Boolean = npcapAvailable
+}

--- a/src/main/kotlin/webview/BrowserApp.kt
+++ b/src/main/kotlin/webview/BrowserApp.kt
@@ -5,7 +5,9 @@ import com.tbread.entity.DpsData
 import com.tbread.logging.DebugLogWriter
 import com.tbread.packet.CaptureDispatcher
 import com.tbread.packet.CombatPortDetector
+import com.tbread.packet.PcapCapturer
 import com.tbread.packet.LocalPlayer
+import com.tbread.packet.PacketCaptureStatus
 import com.tbread.packet.PropertyHandler
 import com.tbread.windows.WindowTitleDetector
 import javafx.animation.KeyFrame
@@ -61,7 +63,8 @@ class BrowserApp(
         val locked: Boolean,
         val characterName: String?,
         val device: String?,
-        val localPlayerId: Long?
+        val localPlayerId: Long?,
+        val npcapAvailable: Boolean
     )
 
     inner class JSBridge(
@@ -83,6 +86,7 @@ class BrowserApp(
         }
 
         fun resetAutoDetection() {
+            PcapCapturer.logDeviceSnapshot("resetAutoDetection")
             CombatPortDetector.reset()
         }
 
@@ -143,7 +147,8 @@ class BrowserApp(
                 locked = lockedPort != null,
                 characterName = LocalPlayer.characterName,
                 device = lockedDevice,
-                localPlayerId = LocalPlayer.playerId
+                localPlayerId = LocalPlayer.playerId,
+                npcapAvailable = PacketCaptureStatus.isNpcapAvailable()
             )
             return Json.encodeToString(info)
         }

--- a/src/main/resources/i18n/ui/en.json
+++ b/src/main/resources/i18n/ui/en.json
@@ -71,6 +71,7 @@
   "settings": {
     "title": "Settings",
     "lockedPort": "Detected device/port",
+    "forceLoopback": "Force local loopback",
     "resetDetection": "Reset",
     "characterName": "Name#ID",
     "characterNamePlaceholder": "Enter your character name",
@@ -158,6 +159,7 @@
   "connection": {
     "auto": "Auto",
     "detecting": "Detecting AION2 connection...",
+    "npcapMissing": "NPcap not found",
     "loopback": "Local Loopback"
   },
   "target": {

--- a/src/main/resources/i18n/ui/ko.json
+++ b/src/main/resources/i18n/ui/ko.json
@@ -69,6 +69,7 @@
   "settings": {
     "title": "설정",
     "lockedPort": "감지된 장치/포트",
+    "forceLoopback": "로컬 루프백 강제",
     "resetDetection": "감지 초기화",
     "characterName": "Name#ID",
     "characterNamePlaceholder": "캐릭터 이름 입력",
@@ -156,6 +157,7 @@
   "connection": {
     "auto": "자동",
     "detecting": "Detecting AION2 connection...",
+    "npcapMissing": "NPcap을 찾을 수 없습니다",
     "loopback": "로컬 루프백"
   },
   "target": {

--- a/src/main/resources/i18n/ui/zh-Hans.json
+++ b/src/main/resources/i18n/ui/zh-Hans.json
@@ -69,6 +69,7 @@
   "settings": {
     "title": "设置",
     "lockedPort": "检测到的设备/端口",
+    "forceLoopback": "强制本地回环",
     "resetDetection": "重置检测",
     "characterName": "Name#ID",
     "characterNamePlaceholder": "输入你的角色名称",
@@ -156,6 +157,7 @@
   "connection": {
     "auto": "自动",
     "detecting": "Detecting AION2 connection...",
+    "npcapMissing": "未找到 NPcap",
     "loopback": "本地回环"
   },
   "target": {

--- a/src/main/resources/i18n/ui/zh-Hant.json
+++ b/src/main/resources/i18n/ui/zh-Hant.json
@@ -69,6 +69,7 @@
   "settings": {
     "title": "設定",
     "lockedPort": "偵測到的裝置/連接埠",
+    "forceLoopback": "強制本地回環",
     "resetDetection": "重置偵測",
     "characterName": "Name#ID",
     "characterNamePlaceholder": "輸入你的角色名稱",
@@ -156,6 +157,7 @@
   "connection": {
     "auto": "自動",
     "detecting": "Detecting AION2 connection...",
+    "npcapMissing": "未找到 NPcap",
     "loopback": "本地回環"
   },
   "target": {

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -422,6 +422,17 @@
             </div>
             <div>
               <label class="settingsToggle">
+                <span class="settingsToggleLabel" data-i18n="settings.forceLoopback">
+                  Force local loopback
+                </span>
+                <span class="settingsToggleControl">
+                  <input type="checkbox" class="forceLoopbackCheckbox" />
+                  <span class="settingsToggleTrack" aria-hidden="true"></span>
+                </span>
+              </label>
+            </div>
+            <div>
+              <label class="settingsToggle">
                 <span class="settingsToggleLabel" data-i18n="settings.debugLogging">
                   Enable debug logging
                 </span>

--- a/src/main/resources/js/core.js
+++ b/src/main/resources/js/core.js
@@ -7,6 +7,7 @@ class DpsApp {
     this.USER_NAME = "";
     this.onlyShowUser = false;
     this.debugLoggingEnabled = false;
+    this.forceLoopbackEnabled = false;
     this.pinMeToTop = false;
     this.includeMainMeterScreenshot = false;
     this.saveScreenshotToFolder = false;
@@ -28,6 +29,7 @@ class DpsApp {
       displayMode: "dpsMeter.displayMode",
       language: "dpsMeter.language",
       debugLogging: "dpsMeter.debugLoggingEnabled",
+      forceLoopback: "dpsMeter.forceLoopback",
       pinMeToTop: "dpsMeter.pinMeToTop",
       theme: "dpsMeter.theme",
     };
@@ -1242,6 +1244,7 @@ class DpsApp {
     this.resetDetectBtn = document.querySelector(".resetDetectBtn");
     this.characterNameInput = document.querySelector(".characterNameInput");
     this.debugLoggingCheckbox = document.querySelector(".debugLoggingCheckbox");
+    this.forceLoopbackCheckbox = document.querySelector(".forceLoopbackCheckbox");
     this.pinMeToTopCheckbox = document.querySelector(".pinMeToTopCheckbox");
     this.meterOpacityInput = document.querySelector(".meterOpacityInput");
     this.meterOpacityValue = document.querySelector(".meterOpacityValue");
@@ -1275,6 +1278,7 @@ class DpsApp {
     const storedMeterOpacity = this.safeGetSetting(this.storageKeys.meterFillOpacity) ||
       this.safeGetStorage(this.storageKeys.meterFillOpacity);
     const storedDebugLogging = this.safeGetSetting(this.storageKeys.debugLogging) === "true";
+    const storedForceLoopback = this.safeGetSetting(this.storageKeys.forceLoopback) === "true";
     const storedPinMeToTop = this.safeGetSetting(this.storageKeys.pinMeToTop) === "true";
     const storedTargetSelection = this.safeGetStorage(this.storageKeys.targetSelection);
     const storedLanguage = this.safeGetStorage(this.storageKeys.language);
@@ -1283,6 +1287,7 @@ class DpsApp {
     this.setUserName(storedName, { persist: false, syncBackend: true });
     this.setOnlyShowUser(false, { persist: false });
     this.setDebugLogging(storedDebugLogging, { persist: false, syncBackend: true });
+    this.setForceLoopback(storedForceLoopback, { persist: false, syncBackend: true });
     this.setPinMeToTop(storedPinMeToTop, { persist: false });
     const normalizedTargetSelection =
       storedTargetSelection === "allTargets" || storedTargetSelection === "trainTargets"
@@ -1349,6 +1354,13 @@ class DpsApp {
       this.debugLoggingCheckbox.addEventListener("change", (event) => {
         const isChecked = !!event.target?.checked;
         this.setDebugLogging(isChecked, { persist: true, syncBackend: true });
+      });
+    }
+    if (this.forceLoopbackCheckbox) {
+      this.forceLoopbackCheckbox.checked = this.forceLoopbackEnabled;
+      this.forceLoopbackCheckbox.addEventListener("change", (event) => {
+        const isChecked = !!event.target?.checked;
+        this.setForceLoopback(isChecked, { persist: true, syncBackend: true, resetDetection: true });
       });
     }
     if (this.pinMeToTopCheckbox) {
@@ -1988,6 +2000,23 @@ class DpsApp {
     }
   }
 
+  setForceLoopback(enabled, { persist = false, syncBackend = false, resetDetection = false } = {}) {
+    this.forceLoopbackEnabled = !!enabled;
+    if (this.forceLoopbackCheckbox && document.activeElement !== this.forceLoopbackCheckbox) {
+      this.forceLoopbackCheckbox.checked = this.forceLoopbackEnabled;
+    }
+    if (persist) {
+      this.safeSetSetting(this.storageKeys.forceLoopback, String(this.forceLoopbackEnabled));
+    }
+    if (syncBackend) {
+      window.javaBridge?.setSetting?.(this.storageKeys.forceLoopback, String(this.forceLoopbackEnabled));
+    }
+    if (resetDetection) {
+      window.javaBridge?.resetAutoDetection?.();
+      this.refreshConnectionInfo();
+    }
+  }
+
   setPinMeToTop(enabled, { persist = false } = {}) {
     this.pinMeToTop = !!enabled;
     if (this.pinMeToTopCheckbox && document.activeElement !== this.pinMeToTopCheckbox) {
@@ -2164,6 +2193,7 @@ class DpsApp {
     }
     const info = this.safeParseJSON(raw, {});
     const previousLocalId = this.localPlayerId;
+    this.npcapAvailable = info?.npcapAvailable !== false;
     const deviceName = typeof info?.device === "string" && info.device.trim() ? info.device : "";
     const rawIp = info?.ip || "-";
     const ip =
@@ -2218,6 +2248,12 @@ class DpsApp {
     if (!this.aionRunning) {
       this.applyConnectionStatusOverride(
         this.i18n?.t("battleTime.notRunning", "AION2 not running") ?? "AION2 not running"
+      );
+      return;
+    }
+    if (this.npcapAvailable === false) {
+      this.applyConnectionStatusOverride(
+        this.i18n?.t("connection.npcapMissing", "NPcap not found") ?? "NPcap not found"
       );
       return;
     }


### PR DESCRIPTION
### Motivation
- Make Npcap devices and loopback-like adapters visible in debug logs when auto-detection is reset so missing loopback adapters can be diagnosed. 
- Improve detection and promotion of combat port candidates including optional forcing of local loopback and more robust magic-count based locking. 
- Capture and persist pre-lock payload samples for offline analysis and decode encapsulated TCP inside raw IP frames when lib parsing is not available.

### Description
- Add `PcapCapturer.logDeviceSnapshot(reason)` to enumerate `Pcaps.findAllDevs()` and log name/description/loopback flag/addresses when `DebugLogWriter` is enabled, and call it from `BrowserApp.resetAutoDetection`. 
- Introduce `PacketCaptureStatus` to record whether pcap devices are available and expose `npcapAvailable` in `BrowserApp.getConnectionInfo()` to allow the UI to show `NPcap not found`. 
- Improve loopback detection in `PcapCapturer` by treating `npf_loopback` and descriptions containing "loopback traffic capture" as loopback-like, and log device inventory and selection decisions. 
- Add a force-loopback setting and UI toggle (`forceLoopback`) wired through `core.js` to persist and sync with backend; `CombatPortDetector` respects the `dpsMeter.forceLoopback` property to prefer loopback-only candidates. 
- Make `CombatPortDetector` track per-port magic counts with a threshold to lock when repeated magic is seen, and clear auxiliary state on reset/clear. 
- Add richer capture-side handling in `PcapCapturer` and `CaptureDispatcher`: decode encapsulated TCP in raw IP frames (`parseRawTcpPayload` / `parseEncapsulatedTcp`), sample logging (`logCaptureSample`, `logEncapsulationSample`, `logTlsSkipSample`) and pre-lock payload capture to `prelock_payloads.log` (size-capped and synchronized). 
- Harden `StreamProcessor` parsing by adding `parseEmbeddedPackets`, better DOT parsing with `logParseFailure` for debug output, and other parsing resilience improvements. 

### Testing
- No automated tests were executed for these changes.
- All debug logging is gated by `DebugLogWriter.isEnabled()` so tests or runtime enablement are required to produce the new logs; no runtime verification was performed in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e9cbc0b08333a01fa11f32be711d)