### PR TITLE
Detect job class from 8-digit skill code prefix

### DIFF
--- a/src/main/kotlin/entity/JobClass.kt
+++ b/src/main/kotlin/entity/JobClass.kt
@@ -1,17 +1,21 @@
 package com.tbread.entity
 
-enum class JobClass(val className: String, val basicSkillCode: Int) {
-    GLADIATOR("검성", 11020000),
-    TEMPLAR("수호성", 12010000),
-    RANGER("궁성", 14020000),
-    ASSASSIN("살성", 13010000),
-    SORCERER("마도성", 15210000), /* 마도 확인 필요함 */
-    CLERIC("치유성", 17010000),
-    ELEMENTALIST("정령성", 16010000),
-    CHANTER("호법성", 18010000);
+enum class JobClass(val className: String, val classPrefix: Int, val basicSkillCode: Int) {
+    GLADIATOR("검성", 11, 11020000),
+    TEMPLAR("수호성", 12, 12010000),
+    RANGER("궁성", 14, 14020000),
+    ASSASSIN("살성", 13, 13010000),
+    SORCERER("마도성", 15, 15210000), /* 마도 확인 필요함 */
+    CLERIC("치유성", 17, 17010000),
+    ELEMENTALIST("정령성", 16, 16010000),
+    CHANTER("호법성", 18, 18010000);
 
     companion object{
         fun convertFromSkill(skillCode:Int):JobClass?{
+            if (skillCode in 10_000_000..99_999_999) {
+                val prefix = skillCode / 1_000_000
+                return entries.find { it.classPrefix == prefix }
+            }
             return entries.find { it.basicSkillCode == skillCode }
         }
     }


### PR DESCRIPTION
### Motivation
- Some class-identification failures occurred when players used skills whose codes belonged to an 8-digit family but did not match a single stored signature skill, so a broader family-based detection is needed.
- The goal is to infer class from the class-specific prefix in 8-digit skill codes so any skill in the same family maps to the correct job.

### Description
- Added a `classPrefix` field to `JobClass` entries and preserved a `basicSkillCode` fallback in `src/main/kotlin/entity/JobClass.kt`.
- Implemented `convertFromSkill` to detect 8-digit codes (`10_000_000..99_999_999`) and compute the prefix as `skillCode / 1_000_000` to match against `classPrefix`.
- Kept an exact-match fallback to `basicSkillCode` for non-8-digit skill formats.

### Testing
- Inspected the updated file with `sed -n '1,120p' src/main/kotlin/entity/JobClass.kt` and `nl -ba src/main/kotlin/entity/JobClass.kt`, and both showed the expected `classPrefix` additions and new logic, indicating the change was applied successfully.
- No automated unit tests were present or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e7d7f75e4832d8c56baa6b8ed0ca1)