### PR TITLE
Bump app version to 0.1.7-pre

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 }
 
 group = "com.tbread"
-version = "1.0.0-pre1"
+version = "0.1.7-pre"
 
 val appVersion = version.toString()
 

--- a/src/main/kotlin/webview/BrowserApp.kt
+++ b/src/main/kotlin/webview/BrowserApp.kt
@@ -420,7 +420,7 @@ class BrowserApp(
 
     private val debugMode = false
 
-    private val version = "1.0.0-pre1"
+    private val version = "0.1.7-pre"
 
     @Volatile
     private var cachedWindowTitle: String? = null


### PR DESCRIPTION
### Motivation
- Align the Gradle project version and the in-app reported version so the UI/bridge and build metadata report `0.1.7-pre` consistently.

### Description
- Updated the Gradle project `version` in `build.gradle.kts` to `0.1.7-pre`.
- Updated the in-app `version` constant in `src/main/kotlin/webview/BrowserApp.kt` to `0.1.7-pre`.

### Testing
- No automated tests were run (per the request to not run tests unless asked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b474585f4832d9c241e0b73f35eee)