### PR TITLE
Guard lookahead scan to prevent ArrayIndexOutOfBounds in damage parser

### DIFF
--- a/src/main/kotlin/packet/StreamProcessor.kt
+++ b/src/main/kotlin/packet/StreamProcessor.kt
@@ -1108,11 +1108,13 @@ class StreamProcessor(private val dataStorage: DataStorage) {
                             packet[reader.offset] in 1..3
 
                     var isNextPacket = false
-                    val lookahead = minOf(15, reader.remainingBytes() - 1)
-                    for (scan in 0..lookahead) {
-                        if (packet[reader.offset + scan] == 0x04.toByte() && packet[reader.offset + scan + 1] == 0x38.toByte()) {
-                            isNextPacket = true
-                            break
+                    if (reader.remainingBytes() >= 2) {
+                        val lookahead = minOf(15, reader.remainingBytes() - 2)
+                        for (scan in 0..lookahead) {
+                            if (packet[reader.offset + scan] == 0x04.toByte() && packet[reader.offset + scan + 1] == 0x38.toByte()) {
+                                isNextPacket = true
+                                break
+                            }
                         }
                     }
 


### PR DESCRIPTION
### Motivation
- The parser intermittently crashed with `ArrayIndexOutOfBoundsException` while scanning for an embedded `0x04 0x38` damage marker in short trailing packet fragments, causing the capture thread to stop. 
- Fix the bounds check without changing parsing semantics so the app continues parsing robustly for malformed/short tails.

### Description
- Added an explicit guard so the `04 38` lookahead scan only runs when at least two bytes remain by checking `reader.remainingBytes() >= 2` before scanning. 
- Adjusted the `lookahead` upper bound from `reader.remainingBytes() - 1` to `reader.remainingBytes() - 2` so `scan + 1` cannot index past the buffer end. 
- Change is localized to `src/main/kotlin/packet/StreamProcessor.kt` inside the multi-hit parsing loop and preserves existing detection and multi-hit logic.

### Testing
- No automated tests were executed against this change; validation was performed via code inspection and a local commit of the updated file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc40f838c832db082c94281956dbe)